### PR TITLE
fix error that could not be `use SemanticWeb::Schema::Place`

### DIFF
--- a/devel/etc/package.tt
+++ b/devel/etc/package.tt
@@ -54,7 +54,7 @@ A [% name %] should be one of the following types:
 
 has [% name %] => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_[% name %]',
     json_ld   => '[% attributes.$name.label %]',
 );
 

--- a/lib/SemanticWeb/Schema/APIReference.pm
+++ b/lib/SemanticWeb/Schema/APIReference.pm
@@ -48,7 +48,7 @@ A assembly should be one of the following types:
 
 has assembly => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_assembly',
     json_ld   => 'assembly',
 );
 
@@ -72,7 +72,7 @@ A assembly_version should be one of the following types:
 
 has assembly_version => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_assembly_version',
     json_ld   => 'assemblyVersion',
 );
 
@@ -96,7 +96,7 @@ A executable_library_name should be one of the following types:
 
 has executable_library_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_executable_library_name',
     json_ld   => 'executableLibraryName',
 );
 
@@ -120,7 +120,7 @@ A programming_model should be one of the following types:
 
 has programming_model => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_programming_model',
     json_ld   => 'programmingModel',
 );
 
@@ -144,7 +144,7 @@ A target_platform should be one of the following types:
 
 has target_platform => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_target_platform',
     json_ld   => 'targetPlatform',
 );
 

--- a/lib/SemanticWeb/Schema/Accommodation.pm
+++ b/lib/SemanticWeb/Schema/Accommodation.pm
@@ -68,7 +68,7 @@ A accommodation_category should be one of the following types:
 
 has accommodation_category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_accommodation_category',
     json_ld   => 'accommodationCategory',
 );
 
@@ -95,7 +95,7 @@ A amenity_feature should be one of the following types:
 
 has amenity_feature => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_amenity_feature',
     json_ld   => 'amenityFeature',
 );
 
@@ -128,7 +128,7 @@ A floor_level should be one of the following types:
 
 has floor_level => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_floor_level',
     json_ld   => 'floorLevel',
 );
 
@@ -154,7 +154,7 @@ A floor_size should be one of the following types:
 
 has floor_size => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_floor_size',
     json_ld   => 'floorSize',
 );
 
@@ -187,7 +187,7 @@ A lease_length should be one of the following types:
 
 has lease_length => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_lease_length',
     json_ld   => 'leaseLength',
 );
 
@@ -222,7 +222,7 @@ A number_of_bathrooms_total should be one of the following types:
 
 has number_of_bathrooms_total => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_bathrooms_total',
     json_ld   => 'numberOfBathroomsTotal',
 );
 
@@ -255,7 +255,7 @@ A number_of_full_bathrooms should be one of the following types:
 
 has number_of_full_bathrooms => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_full_bathrooms',
     json_ld   => 'numberOfFullBathrooms',
 );
 
@@ -284,7 +284,7 @@ A number_of_rooms should be one of the following types:
 
 has number_of_rooms => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_rooms',
     json_ld   => 'numberOfRooms',
 );
 
@@ -308,7 +308,7 @@ A permitted_usage should be one of the following types:
 
 has permitted_usage => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_permitted_usage',
     json_ld   => 'permittedUsage',
 );
 
@@ -335,7 +335,7 @@ A pets_allowed should be one of the following types:
 
 has pets_allowed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pets_allowed',
     json_ld   => 'petsAllowed',
 );
 

--- a/lib/SemanticWeb/Schema/Action.pm
+++ b/lib/SemanticWeb/Schema/Action.pm
@@ -59,7 +59,7 @@ A action_status should be one of the following types:
 
 has action_status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_action_status',
     json_ld   => 'actionStatus',
 );
 
@@ -90,7 +90,7 @@ A agent should be one of the following types:
 
 has agent => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_agent',
     json_ld   => 'agent',
 );
 
@@ -125,7 +125,7 @@ A end_time should be one of the following types:
 
 has end_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_end_time',
     json_ld   => 'endTime',
 );
 
@@ -149,7 +149,7 @@ A error should be one of the following types:
 
 has error => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_error',
     json_ld   => 'error',
 );
 
@@ -178,7 +178,7 @@ A instrument should be one of the following types:
 
 has instrument => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_instrument',
     json_ld   => 'instrument',
 );
 
@@ -207,7 +207,7 @@ A location should be one of the following types:
 
 has location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_location',
     json_ld   => 'location',
 );
 
@@ -238,7 +238,7 @@ A object should be one of the following types:
 
 has object => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_object',
     json_ld   => 'object',
 );
 
@@ -269,7 +269,7 @@ A participant should be one of the following types:
 
 has participant => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_participant',
     json_ld   => 'participant',
 );
 
@@ -297,7 +297,7 @@ A result should be one of the following types:
 
 has result => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_result',
     json_ld   => 'result',
 );
 
@@ -332,7 +332,7 @@ A start_time should be one of the following types:
 
 has start_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_start_time',
     json_ld   => 'startTime',
 );
 
@@ -356,7 +356,7 @@ A target should be one of the following types:
 
 has target => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_target',
     json_ld   => 'target',
 );
 

--- a/lib/SemanticWeb/Schema/ActionAccessSpecification.pm
+++ b/lib/SemanticWeb/Schema/ActionAccessSpecification.pm
@@ -50,7 +50,7 @@ A availability_ends should be one of the following types:
 
 has availability_ends => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_availability_ends',
     json_ld   => 'availabilityEnds',
 );
 
@@ -75,7 +75,7 @@ A availability_starts should be one of the following types:
 
 has availability_starts => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_availability_starts',
     json_ld   => 'availabilityStarts',
 );
 
@@ -104,7 +104,7 @@ A category should be one of the following types:
 
 has category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_category',
     json_ld   => 'category',
 );
 
@@ -140,7 +140,7 @@ A eligible_region should be one of the following types:
 
 has eligible_region => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_eligible_region',
     json_ld   => 'eligibleRegion',
 );
 
@@ -165,7 +165,7 @@ A expects_acceptance_of should be one of the following types:
 
 has expects_acceptance_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_expects_acceptance_of',
     json_ld   => 'expectsAcceptanceOf',
 );
 
@@ -201,7 +201,7 @@ A ineligible_region should be one of the following types:
 
 has ineligible_region => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ineligible_region',
     json_ld   => 'ineligibleRegion',
 );
 
@@ -233,7 +233,7 @@ A requires_subscription should be one of the following types:
 
 has requires_subscription => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_requires_subscription',
     json_ld   => 'requiresSubscription',
 );
 

--- a/lib/SemanticWeb/Schema/AggregateOffer.pm
+++ b/lib/SemanticWeb/Schema/AggregateOffer.pm
@@ -61,7 +61,7 @@ A high_price should be one of the following types:
 
 has high_price => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_high_price',
     json_ld   => 'highPrice',
 );
 
@@ -96,7 +96,7 @@ A low_price should be one of the following types:
 
 has low_price => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_low_price',
     json_ld   => 'lowPrice',
 );
 
@@ -120,7 +120,7 @@ A offer_count should be one of the following types:
 
 has offer_count => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_offer_count',
     json_ld   => 'offerCount',
 );
 
@@ -146,7 +146,7 @@ A offers should be one of the following types:
 
 has offers => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_offers',
     json_ld   => 'offers',
 );
 

--- a/lib/SemanticWeb/Schema/AggregateRating.pm
+++ b/lib/SemanticWeb/Schema/AggregateRating.pm
@@ -48,7 +48,7 @@ A item_reviewed should be one of the following types:
 
 has item_reviewed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_item_reviewed',
     json_ld   => 'itemReviewed',
 );
 
@@ -72,7 +72,7 @@ A rating_count should be one of the following types:
 
 has rating_count => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_rating_count',
     json_ld   => 'ratingCount',
 );
 
@@ -96,7 +96,7 @@ A review_count should be one of the following types:
 
 has review_count => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_review_count',
     json_ld   => 'reviewCount',
 );
 

--- a/lib/SemanticWeb/Schema/Airline.pm
+++ b/lib/SemanticWeb/Schema/Airline.pm
@@ -49,7 +49,7 @@ A boarding_policy should be one of the following types:
 
 has boarding_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_boarding_policy',
     json_ld   => 'boardingPolicy',
 );
 
@@ -73,7 +73,7 @@ A iata_code should be one of the following types:
 
 has iata_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_iata_code',
     json_ld   => 'iataCode',
 );
 

--- a/lib/SemanticWeb/Schema/Airport.pm
+++ b/lib/SemanticWeb/Schema/Airport.pm
@@ -48,7 +48,7 @@ A iata_code should be one of the following types:
 
 has iata_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_iata_code',
     json_ld   => 'iataCode',
 );
 
@@ -72,7 +72,7 @@ A icao_code should be one of the following types:
 
 has icao_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_icao_code',
     json_ld   => 'icaoCode',
 );
 

--- a/lib/SemanticWeb/Schema/AlignmentObject.pm
+++ b/lib/SemanticWeb/Schema/AlignmentObject.pm
@@ -52,7 +52,7 @@ A alignment_type should be one of the following types:
 
 has alignment_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_alignment_type',
     json_ld   => 'alignmentType',
 );
 
@@ -76,7 +76,7 @@ A educational_framework should be one of the following types:
 
 has educational_framework => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_educational_framework',
     json_ld   => 'educationalFramework',
 );
 
@@ -100,7 +100,7 @@ A target_description should be one of the following types:
 
 has target_description => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_target_description',
     json_ld   => 'targetDescription',
 );
 
@@ -124,7 +124,7 @@ A target_name should be one of the following types:
 
 has target_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_target_name',
     json_ld   => 'targetName',
 );
 
@@ -148,7 +148,7 @@ A target_url should be one of the following types:
 
 has target_url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_target_url',
     json_ld   => 'targetUrl',
 );
 

--- a/lib/SemanticWeb/Schema/AllocateAction.pm
+++ b/lib/SemanticWeb/Schema/AllocateAction.pm
@@ -50,7 +50,7 @@ A purpose should be one of the following types:
 
 has purpose => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_purpose',
     json_ld   => 'purpose',
 );
 

--- a/lib/SemanticWeb/Schema/AnatomicalStructure.pm
+++ b/lib/SemanticWeb/Schema/AnatomicalStructure.pm
@@ -51,7 +51,7 @@ A associated_pathophysiology should be one of the following types:
 
 has associated_pathophysiology => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_associated_pathophysiology',
     json_ld   => 'associatedPathophysiology',
 );
 
@@ -75,7 +75,7 @@ A body_location should be one of the following types:
 
 has body_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_body_location',
     json_ld   => 'bodyLocation',
 );
 
@@ -99,7 +99,7 @@ A connected_to should be one of the following types:
 
 has connected_to => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_connected_to',
     json_ld   => 'connectedTo',
 );
 
@@ -124,7 +124,7 @@ A diagram should be one of the following types:
 
 has diagram => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_diagram',
     json_ld   => 'diagram',
 );
 
@@ -148,7 +148,7 @@ A function should be one of the following types:
 
 has function => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_function',
     json_ld   => 'function',
 );
 
@@ -172,7 +172,7 @@ A part_of_system should be one of the following types:
 
 has part_of_system => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_part_of_system',
     json_ld   => 'partOfSystem',
 );
 
@@ -196,7 +196,7 @@ A related_condition should be one of the following types:
 
 has related_condition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_related_condition',
     json_ld   => 'relatedCondition',
 );
 
@@ -220,7 +220,7 @@ A related_therapy should be one of the following types:
 
 has related_therapy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_related_therapy',
     json_ld   => 'relatedTherapy',
 );
 
@@ -244,7 +244,7 @@ A sub_structure should be one of the following types:
 
 has sub_structure => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sub_structure',
     json_ld   => 'subStructure',
 );
 

--- a/lib/SemanticWeb/Schema/AnatomicalSystem.pm
+++ b/lib/SemanticWeb/Schema/AnatomicalSystem.pm
@@ -55,7 +55,7 @@ A associated_pathophysiology should be one of the following types:
 
 has associated_pathophysiology => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_associated_pathophysiology',
     json_ld   => 'associatedPathophysiology',
 );
 
@@ -83,7 +83,7 @@ A comprised_of should be one of the following types:
 
 has comprised_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_comprised_of',
     json_ld   => 'comprisedOf',
 );
 
@@ -107,7 +107,7 @@ A related_condition should be one of the following types:
 
 has related_condition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_related_condition',
     json_ld   => 'relatedCondition',
 );
 
@@ -132,7 +132,7 @@ A related_structure should be one of the following types:
 
 has related_structure => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_related_structure',
     json_ld   => 'relatedStructure',
 );
 
@@ -156,7 +156,7 @@ A related_therapy should be one of the following types:
 
 has related_therapy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_related_therapy',
     json_ld   => 'relatedTherapy',
 );
 

--- a/lib/SemanticWeb/Schema/Apartment.pm
+++ b/lib/SemanticWeb/Schema/Apartment.pm
@@ -62,7 +62,7 @@ A number_of_rooms should be one of the following types:
 
 has number_of_rooms => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_rooms',
     json_ld   => 'numberOfRooms',
 );
 
@@ -90,7 +90,7 @@ A occupancy should be one of the following types:
 
 has occupancy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_occupancy',
     json_ld   => 'occupancy',
 );
 

--- a/lib/SemanticWeb/Schema/ArchiveComponent.pm
+++ b/lib/SemanticWeb/Schema/ArchiveComponent.pm
@@ -56,7 +56,7 @@ A holding_archive should be one of the following types:
 
 has holding_archive => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_holding_archive',
     json_ld   => 'holdingArchive',
 );
 
@@ -84,7 +84,7 @@ A item_location should be one of the following types:
 
 has item_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_item_location',
     json_ld   => 'itemLocation',
 );
 

--- a/lib/SemanticWeb/Schema/ArchiveOrganization.pm
+++ b/lib/SemanticWeb/Schema/ArchiveOrganization.pm
@@ -56,7 +56,7 @@ A archive_held should be one of the following types:
 
 has archive_held => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_archive_held',
     json_ld   => 'archiveHeld',
 );
 

--- a/lib/SemanticWeb/Schema/Artery.pm
+++ b/lib/SemanticWeb/Schema/Artery.pm
@@ -48,7 +48,7 @@ A arterial_branch should be one of the following types:
 
 has arterial_branch => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_arterial_branch',
     json_ld   => 'arterialBranch',
 );
 
@@ -72,7 +72,7 @@ A source should be one of the following types:
 
 has source => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_source',
     json_ld   => 'source',
 );
 
@@ -96,7 +96,7 @@ A supply_to should be one of the following types:
 
 has supply_to => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_supply_to',
     json_ld   => 'supplyTo',
 );
 

--- a/lib/SemanticWeb/Schema/Article.pm
+++ b/lib/SemanticWeb/Schema/Article.pm
@@ -56,7 +56,7 @@ A article_body should be one of the following types:
 
 has article_body => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_article_body',
     json_ld   => 'articleBody',
 );
 
@@ -81,7 +81,7 @@ A article_section should be one of the following types:
 
 has article_section => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_article_section',
     json_ld   => 'articleSection',
 );
 
@@ -117,7 +117,7 @@ A backstory should be one of the following types:
 
 has backstory => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_backstory',
     json_ld   => 'backstory',
 );
 
@@ -143,7 +143,7 @@ A page_end should be one of the following types:
 
 has page_end => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_page_end',
     json_ld   => 'pageEnd',
 );
 
@@ -169,7 +169,7 @@ A page_start should be one of the following types:
 
 has page_start => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_page_start',
     json_ld   => 'pageStart',
 );
 
@@ -194,7 +194,7 @@ A pagination should be one of the following types:
 
 has pagination => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pagination',
     json_ld   => 'pagination',
 );
 
@@ -245,7 +245,7 @@ A speakable should be one of the following types:
 
 has speakable => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_speakable',
     json_ld   => 'speakable',
 );
 
@@ -269,7 +269,7 @@ A word_count should be one of the following types:
 
 has word_count => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_word_count',
     json_ld   => 'wordCount',
 );
 

--- a/lib/SemanticWeb/Schema/AskAction.pm
+++ b/lib/SemanticWeb/Schema/AskAction.pm
@@ -55,7 +55,7 @@ A question should be one of the following types:
 
 has question => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_question',
     json_ld   => 'question',
 );
 

--- a/lib/SemanticWeb/Schema/Audience.pm
+++ b/lib/SemanticWeb/Schema/Audience.pm
@@ -50,7 +50,7 @@ A audience_type should be one of the following types:
 
 has audience_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_audience_type',
     json_ld   => 'audienceType',
 );
 
@@ -74,7 +74,7 @@ A geographic_area should be one of the following types:
 
 has geographic_area => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geographic_area',
     json_ld   => 'geographicArea',
 );
 

--- a/lib/SemanticWeb/Schema/AudioObject.pm
+++ b/lib/SemanticWeb/Schema/AudioObject.pm
@@ -57,7 +57,7 @@ A caption should be one of the following types:
 
 has caption => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_caption',
     json_ld   => 'caption',
 );
 
@@ -82,7 +82,7 @@ A transcript should be one of the following types:
 
 has transcript => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_transcript',
     json_ld   => 'transcript',
 );
 

--- a/lib/SemanticWeb/Schema/Audiobook.pm
+++ b/lib/SemanticWeb/Schema/Audiobook.pm
@@ -53,7 +53,7 @@ A duration should be one of the following types:
 
 has duration => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_duration',
     json_ld   => 'duration',
 );
 
@@ -77,7 +77,7 @@ A read_by should be one of the following types:
 
 has read_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_read_by',
     json_ld   => 'readBy',
 );
 

--- a/lib/SemanticWeb/Schema/AuthorizeAction.pm
+++ b/lib/SemanticWeb/Schema/AuthorizeAction.pm
@@ -55,7 +55,7 @@ A recipient should be one of the following types:
 
 has recipient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipient',
     json_ld   => 'recipient',
 );
 

--- a/lib/SemanticWeb/Schema/BankAccount.pm
+++ b/lib/SemanticWeb/Schema/BankAccount.pm
@@ -49,7 +49,7 @@ A account_minimum_inflow should be one of the following types:
 
 has account_minimum_inflow => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_account_minimum_inflow',
     json_ld   => 'accountMinimumInflow',
 );
 
@@ -76,7 +76,7 @@ A account_overdraft_limit should be one of the following types:
 
 has account_overdraft_limit => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_account_overdraft_limit',
     json_ld   => 'accountOverdraftLimit',
 );
 
@@ -100,7 +100,7 @@ A bank_account_type should be one of the following types:
 
 has bank_account_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_bank_account_type',
     json_ld   => 'bankAccountType',
 );
 

--- a/lib/SemanticWeb/Schema/BedDetails.pm
+++ b/lib/SemanticWeb/Schema/BedDetails.pm
@@ -57,7 +57,7 @@ A number_of_beds should be one of the following types:
 
 has number_of_beds => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_beds',
     json_ld   => 'numberOfBeds',
 );
 
@@ -84,7 +84,7 @@ A type_of_bed should be one of the following types:
 
 has type_of_bed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_type_of_bed',
     json_ld   => 'typeOfBed',
 );
 

--- a/lib/SemanticWeb/Schema/Blog.pm
+++ b/lib/SemanticWeb/Schema/Blog.pm
@@ -48,7 +48,7 @@ A blog_post should be one of the following types:
 
 has blog_post => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_blog_post',
     json_ld   => 'blogPost',
 );
 
@@ -72,7 +72,7 @@ A blog_posts should be one of the following types:
 
 has blog_posts => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_blog_posts',
     json_ld   => 'blogPosts',
 );
 
@@ -98,7 +98,7 @@ A issn should be one of the following types:
 
 has issn => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_issn',
     json_ld   => 'issn',
 );
 

--- a/lib/SemanticWeb/Schema/Book.pm
+++ b/lib/SemanticWeb/Schema/Book.pm
@@ -48,7 +48,7 @@ A abridged should be one of the following types:
 
 has abridged => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_abridged',
     json_ld   => 'abridged',
 );
 
@@ -72,7 +72,7 @@ A book_edition should be one of the following types:
 
 has book_edition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_book_edition',
     json_ld   => 'bookEdition',
 );
 
@@ -96,7 +96,7 @@ A book_format should be one of the following types:
 
 has book_format => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_book_format',
     json_ld   => 'bookFormat',
 );
 
@@ -120,7 +120,7 @@ A illustrator should be one of the following types:
 
 has illustrator => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_illustrator',
     json_ld   => 'illustrator',
 );
 
@@ -144,7 +144,7 @@ A isbn should be one of the following types:
 
 has isbn => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_isbn',
     json_ld   => 'isbn',
 );
 
@@ -168,7 +168,7 @@ A number_of_pages should be one of the following types:
 
 has number_of_pages => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_pages',
     json_ld   => 'numberOfPages',
 );
 

--- a/lib/SemanticWeb/Schema/BorrowAction.pm
+++ b/lib/SemanticWeb/Schema/BorrowAction.pm
@@ -59,7 +59,7 @@ A lender should be one of the following types:
 
 has lender => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_lender',
     json_ld   => 'lender',
 );
 

--- a/lib/SemanticWeb/Schema/Brand.pm
+++ b/lib/SemanticWeb/Schema/Brand.pm
@@ -50,7 +50,7 @@ A aggregate_rating should be one of the following types:
 
 has aggregate_rating => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_aggregate_rating',
     json_ld   => 'aggregateRating',
 );
 
@@ -76,7 +76,7 @@ A logo should be one of the following types:
 
 has logo => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_logo',
     json_ld   => 'logo',
 );
 
@@ -100,7 +100,7 @@ A review should be one of the following types:
 
 has review => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_review',
     json_ld   => 'review',
 );
 
@@ -124,7 +124,7 @@ A slogan should be one of the following types:
 
 has slogan => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_slogan',
     json_ld   => 'slogan',
 );
 

--- a/lib/SemanticWeb/Schema/BroadcastChannel.pm
+++ b/lib/SemanticWeb/Schema/BroadcastChannel.pm
@@ -50,7 +50,7 @@ A broadcast_channel_id should be one of the following types:
 
 has broadcast_channel_id => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broadcast_channel_id',
     json_ld   => 'broadcastChannelId',
 );
 
@@ -78,7 +78,7 @@ A broadcast_frequency should be one of the following types:
 
 has broadcast_frequency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broadcast_frequency',
     json_ld   => 'broadcastFrequency',
 );
 
@@ -103,7 +103,7 @@ A broadcast_service_tier should be one of the following types:
 
 has broadcast_service_tier => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broadcast_service_tier',
     json_ld   => 'broadcastServiceTier',
 );
 
@@ -127,7 +127,7 @@ A genre should be one of the following types:
 
 has genre => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_genre',
     json_ld   => 'genre',
 );
 
@@ -151,7 +151,7 @@ A in_broadcast_lineup should be one of the following types:
 
 has in_broadcast_lineup => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_in_broadcast_lineup',
     json_ld   => 'inBroadcastLineup',
 );
 
@@ -175,7 +175,7 @@ A provides_broadcast_service should be one of the following types:
 
 has provides_broadcast_service => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_provides_broadcast_service',
     json_ld   => 'providesBroadcastService',
 );
 

--- a/lib/SemanticWeb/Schema/BroadcastEvent.pm
+++ b/lib/SemanticWeb/Schema/BroadcastEvent.pm
@@ -48,7 +48,7 @@ A broadcast_of_event should be one of the following types:
 
 has broadcast_of_event => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broadcast_of_event',
     json_ld   => 'broadcastOfEvent',
 );
 
@@ -72,7 +72,7 @@ A is_live_broadcast should be one of the following types:
 
 has is_live_broadcast => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_live_broadcast',
     json_ld   => 'isLiveBroadcast',
 );
 
@@ -103,7 +103,7 @@ A subtitle_language should be one of the following types:
 
 has subtitle_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_subtitle_language',
     json_ld   => 'subtitleLanguage',
 );
 
@@ -128,7 +128,7 @@ A video_format should be one of the following types:
 
 has video_format => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_video_format',
     json_ld   => 'videoFormat',
 );
 

--- a/lib/SemanticWeb/Schema/BroadcastFrequencySpecification.pm
+++ b/lib/SemanticWeb/Schema/BroadcastFrequencySpecification.pm
@@ -51,7 +51,7 @@ A broadcast_frequency_value should be one of the following types:
 
 has broadcast_frequency_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broadcast_frequency_value',
     json_ld   => 'broadcastFrequencyValue',
 );
 
@@ -77,7 +77,7 @@ A broadcast_signal_modulation should be one of the following types:
 
 has broadcast_signal_modulation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broadcast_signal_modulation',
     json_ld   => 'broadcastSignalModulation',
 );
 
@@ -101,7 +101,7 @@ A broadcast_sub_channel should be one of the following types:
 
 has broadcast_sub_channel => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broadcast_sub_channel',
     json_ld   => 'broadcastSubChannel',
 );
 

--- a/lib/SemanticWeb/Schema/BroadcastService.pm
+++ b/lib/SemanticWeb/Schema/BroadcastService.pm
@@ -49,7 +49,7 @@ A area should be one of the following types:
 
 has area => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_area',
     json_ld   => 'area',
 );
 
@@ -73,7 +73,7 @@ A broadcast_affiliate_of should be one of the following types:
 
 has broadcast_affiliate_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broadcast_affiliate_of',
     json_ld   => 'broadcastAffiliateOf',
 );
 
@@ -98,7 +98,7 @@ A broadcast_display_name should be one of the following types:
 
 has broadcast_display_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broadcast_display_name',
     json_ld   => 'broadcastDisplayName',
 );
 
@@ -126,7 +126,7 @@ A broadcast_frequency should be one of the following types:
 
 has broadcast_frequency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broadcast_frequency',
     json_ld   => 'broadcastFrequency',
 );
 
@@ -155,7 +155,7 @@ A broadcast_timezone should be one of the following types:
 
 has broadcast_timezone => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broadcast_timezone',
     json_ld   => 'broadcastTimezone',
 );
 
@@ -179,7 +179,7 @@ A broadcaster should be one of the following types:
 
 has broadcaster => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broadcaster',
     json_ld   => 'broadcaster',
 );
 
@@ -209,7 +209,7 @@ A call_sign should be one of the following types:
 
 has call_sign => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_call_sign',
     json_ld   => 'callSign',
 );
 
@@ -233,7 +233,7 @@ A has_broadcast_channel should be one of the following types:
 
 has has_broadcast_channel => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_broadcast_channel',
     json_ld   => 'hasBroadcastChannel',
 );
 
@@ -258,7 +258,7 @@ A parent_service should be one of the following types:
 
 has parent_service => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_parent_service',
     json_ld   => 'parentService',
 );
 
@@ -283,7 +283,7 @@ A video_format should be one of the following types:
 
 has video_format => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_video_format',
     json_ld   => 'videoFormat',
 );
 

--- a/lib/SemanticWeb/Schema/BusOrCoach.pm
+++ b/lib/SemanticWeb/Schema/BusOrCoach.pm
@@ -52,7 +52,7 @@ A acriss_code should be one of the following types:
 
 has acriss_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_acriss_code',
     json_ld   => 'acrissCode',
 );
 
@@ -93,7 +93,7 @@ A roof_load should be one of the following types:
 
 has roof_load => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_roof_load',
     json_ld   => 'roofLoad',
 );
 

--- a/lib/SemanticWeb/Schema/BusTrip.pm
+++ b/lib/SemanticWeb/Schema/BusTrip.pm
@@ -50,7 +50,7 @@ A arrival_bus_stop should be one of the following types:
 
 has arrival_bus_stop => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_arrival_bus_stop',
     json_ld   => 'arrivalBusStop',
 );
 
@@ -74,7 +74,7 @@ A bus_name should be one of the following types:
 
 has bus_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_bus_name',
     json_ld   => 'busName',
 );
 
@@ -98,7 +98,7 @@ A bus_number should be one of the following types:
 
 has bus_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_bus_number',
     json_ld   => 'busNumber',
 );
 
@@ -124,7 +124,7 @@ A departure_bus_stop should be one of the following types:
 
 has departure_bus_stop => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_departure_bus_stop',
     json_ld   => 'departureBusStop',
 );
 

--- a/lib/SemanticWeb/Schema/BusinessAudience.pm
+++ b/lib/SemanticWeb/Schema/BusinessAudience.pm
@@ -49,7 +49,7 @@ A number_of_employees should be one of the following types:
 
 has number_of_employees => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_employees',
     json_ld   => 'numberOfEmployees',
 );
 
@@ -73,7 +73,7 @@ A yearly_revenue should be one of the following types:
 
 has yearly_revenue => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_yearly_revenue',
     json_ld   => 'yearlyRevenue',
 );
 
@@ -97,7 +97,7 @@ A years_in_operation should be one of the following types:
 
 has years_in_operation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_years_in_operation',
     json_ld   => 'yearsInOperation',
 );
 

--- a/lib/SemanticWeb/Schema/BuyAction.pm
+++ b/lib/SemanticWeb/Schema/BuyAction.pm
@@ -53,7 +53,7 @@ A seller should be one of the following types:
 
 has seller => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seller',
     json_ld   => 'seller',
 );
 
@@ -79,7 +79,7 @@ A vendor should be one of the following types:
 
 has vendor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_vendor',
     json_ld   => 'vendor',
 );
 
@@ -103,7 +103,7 @@ A warranty_promise should be one of the following types:
 
 has warranty_promise => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_warranty_promise',
     json_ld   => 'warrantyPromise',
 );
 

--- a/lib/SemanticWeb/Schema/Car.pm
+++ b/lib/SemanticWeb/Schema/Car.pm
@@ -50,7 +50,7 @@ A acriss_code should be one of the following types:
 
 has acriss_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_acriss_code',
     json_ld   => 'acrissCode',
 );
 
@@ -91,7 +91,7 @@ A roof_load should be one of the following types:
 
 has roof_load => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_roof_load',
     json_ld   => 'roofLoad',
 );
 

--- a/lib/SemanticWeb/Schema/CategoryCode.pm
+++ b/lib/SemanticWeb/Schema/CategoryCode.pm
@@ -48,7 +48,7 @@ A code_value should be one of the following types:
 
 has code_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_code_value',
     json_ld   => 'codeValue',
 );
 
@@ -80,7 +80,7 @@ A in_code_set should be one of the following types:
 
 has in_code_set => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_in_code_set',
     json_ld   => 'inCodeSet',
 );
 

--- a/lib/SemanticWeb/Schema/CategoryCodeSet.pm
+++ b/lib/SemanticWeb/Schema/CategoryCodeSet.pm
@@ -48,7 +48,7 @@ A has_category_code should be one of the following types:
 
 has has_category_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_category_code',
     json_ld   => 'hasCategoryCode',
 );
 

--- a/lib/SemanticWeb/Schema/Chapter.pm
+++ b/lib/SemanticWeb/Schema/Chapter.pm
@@ -51,7 +51,7 @@ A page_end should be one of the following types:
 
 has page_end => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_page_end',
     json_ld   => 'pageEnd',
 );
 
@@ -77,7 +77,7 @@ A page_start should be one of the following types:
 
 has page_start => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_page_start',
     json_ld   => 'pageStart',
 );
 
@@ -102,7 +102,7 @@ A pagination should be one of the following types:
 
 has pagination => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pagination',
     json_ld   => 'pagination',
 );
 

--- a/lib/SemanticWeb/Schema/ChooseAction.pm
+++ b/lib/SemanticWeb/Schema/ChooseAction.pm
@@ -51,7 +51,7 @@ A action_option should be one of the following types:
 
 has action_option => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_action_option',
     json_ld   => 'actionOption',
 );
 
@@ -77,7 +77,7 @@ A option should be one of the following types:
 
 has option => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_option',
     json_ld   => 'option',
 );
 

--- a/lib/SemanticWeb/Schema/CivicStructure.pm
+++ b/lib/SemanticWeb/Schema/CivicStructure.pm
@@ -65,7 +65,7 @@ A opening_hours should be one of the following types:
 
 has opening_hours => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_opening_hours',
     json_ld   => 'openingHours',
 );
 

--- a/lib/SemanticWeb/Schema/Claim.pm
+++ b/lib/SemanticWeb/Schema/Claim.pm
@@ -80,7 +80,7 @@ A appearance should be one of the following types:
 
 has appearance => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_appearance',
     json_ld   => 'appearance',
 );
 
@@ -110,7 +110,7 @@ A first_appearance should be one of the following types:
 
 has first_appearance => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_first_appearance',
     json_ld   => 'firstAppearance',
 );
 

--- a/lib/SemanticWeb/Schema/ClaimReview.pm
+++ b/lib/SemanticWeb/Schema/ClaimReview.pm
@@ -49,7 +49,7 @@ A claim_reviewed should be one of the following types:
 
 has claim_reviewed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_claim_reviewed',
     json_ld   => 'claimReviewed',
 );
 

--- a/lib/SemanticWeb/Schema/Class.pm
+++ b/lib/SemanticWeb/Schema/Class.pm
@@ -53,7 +53,7 @@ A superseded_by should be one of the following types:
 
 has superseded_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_superseded_by',
     json_ld   => 'supersededBy',
 );
 

--- a/lib/SemanticWeb/Schema/Clip.pm
+++ b/lib/SemanticWeb/Schema/Clip.pm
@@ -50,7 +50,7 @@ A actor should be one of the following types:
 
 has actor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actor',
     json_ld   => 'actor',
 );
 
@@ -75,7 +75,7 @@ A actors should be one of the following types:
 
 has actors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actors',
     json_ld   => 'actors',
 );
 
@@ -101,7 +101,7 @@ A clip_number should be one of the following types:
 
 has clip_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_clip_number',
     json_ld   => 'clipNumber',
 );
 
@@ -127,7 +127,7 @@ A director should be one of the following types:
 
 has director => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_director',
     json_ld   => 'director',
 );
 
@@ -152,7 +152,7 @@ A directors should be one of the following types:
 
 has directors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_directors',
     json_ld   => 'directors',
 );
 
@@ -177,7 +177,7 @@ A end_offset should be one of the following types:
 
 has end_offset => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_end_offset',
     json_ld   => 'endOffset',
 );
 
@@ -203,7 +203,7 @@ A music_by should be one of the following types:
 
 has music_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_music_by',
     json_ld   => 'musicBy',
 );
 
@@ -227,7 +227,7 @@ A part_of_episode should be one of the following types:
 
 has part_of_episode => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_part_of_episode',
     json_ld   => 'partOfEpisode',
 );
 
@@ -251,7 +251,7 @@ A part_of_season should be one of the following types:
 
 has part_of_season => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_part_of_season',
     json_ld   => 'partOfSeason',
 );
 
@@ -275,7 +275,7 @@ A part_of_series should be one of the following types:
 
 has part_of_series => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_part_of_series',
     json_ld   => 'partOfSeries',
 );
 
@@ -300,7 +300,7 @@ A start_offset should be one of the following types:
 
 has start_offset => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_start_offset',
     json_ld   => 'startOffset',
 );
 

--- a/lib/SemanticWeb/Schema/Collection.pm
+++ b/lib/SemanticWeb/Schema/Collection.pm
@@ -53,7 +53,7 @@ A collection_size should be one of the following types:
 
 has collection_size => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_collection_size',
     json_ld   => 'collectionSize',
 );
 

--- a/lib/SemanticWeb/Schema/ComicIssue.pm
+++ b/lib/SemanticWeb/Schema/ComicIssue.pm
@@ -55,7 +55,7 @@ A artist should be one of the following types:
 
 has artist => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_artist',
     json_ld   => 'artist',
 );
 
@@ -79,7 +79,7 @@ A colorist should be one of the following types:
 
 has colorist => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_colorist',
     json_ld   => 'colorist',
 );
 
@@ -104,7 +104,7 @@ A inker should be one of the following types:
 
 has inker => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_inker',
     json_ld   => 'inker',
 );
 
@@ -129,7 +129,7 @@ A letterer should be one of the following types:
 
 has letterer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_letterer',
     json_ld   => 'letterer',
 );
 
@@ -153,7 +153,7 @@ A penciler should be one of the following types:
 
 has penciler => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_penciler',
     json_ld   => 'penciler',
 );
 
@@ -179,7 +179,7 @@ A variant_cover should be one of the following types:
 
 has variant_cover => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_variant_cover',
     json_ld   => 'variantCover',
 );
 

--- a/lib/SemanticWeb/Schema/ComicStory.pm
+++ b/lib/SemanticWeb/Schema/ComicStory.pm
@@ -52,7 +52,7 @@ A artist should be one of the following types:
 
 has artist => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_artist',
     json_ld   => 'artist',
 );
 
@@ -76,7 +76,7 @@ A colorist should be one of the following types:
 
 has colorist => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_colorist',
     json_ld   => 'colorist',
 );
 
@@ -101,7 +101,7 @@ A inker should be one of the following types:
 
 has inker => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_inker',
     json_ld   => 'inker',
 );
 
@@ -126,7 +126,7 @@ A letterer should be one of the following types:
 
 has letterer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_letterer',
     json_ld   => 'letterer',
 );
 
@@ -150,7 +150,7 @@ A penciler should be one of the following types:
 
 has penciler => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_penciler',
     json_ld   => 'penciler',
 );
 

--- a/lib/SemanticWeb/Schema/Comment.pm
+++ b/lib/SemanticWeb/Schema/Comment.pm
@@ -57,7 +57,7 @@ A downvote_count should be one of the following types:
 
 has downvote_count => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_downvote_count',
     json_ld   => 'downvoteCount',
 );
 
@@ -81,7 +81,7 @@ A parent_item should be one of the following types:
 
 has parent_item => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_parent_item',
     json_ld   => 'parentItem',
 );
 
@@ -106,7 +106,7 @@ A upvote_count should be one of the following types:
 
 has upvote_count => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_upvote_count',
     json_ld   => 'upvoteCount',
 );
 

--- a/lib/SemanticWeb/Schema/CommentAction.pm
+++ b/lib/SemanticWeb/Schema/CommentAction.pm
@@ -49,7 +49,7 @@ A result_comment should be one of the following types:
 
 has result_comment => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_result_comment',
     json_ld   => 'resultComment',
 );
 

--- a/lib/SemanticWeb/Schema/CommunicateAction.pm
+++ b/lib/SemanticWeb/Schema/CommunicateAction.pm
@@ -49,7 +49,7 @@ A about should be one of the following types:
 
 has about => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_about',
     json_ld   => 'about',
 );
 
@@ -83,7 +83,7 @@ A in_language should be one of the following types:
 
 has in_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_in_language',
     json_ld   => 'inLanguage',
 );
 
@@ -107,7 +107,7 @@ A language should be one of the following types:
 
 has language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_language',
     json_ld   => 'language',
 );
 
@@ -138,7 +138,7 @@ A recipient should be one of the following types:
 
 has recipient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipient',
     json_ld   => 'recipient',
 );
 

--- a/lib/SemanticWeb/Schema/CompoundPriceSpecification.pm
+++ b/lib/SemanticWeb/Schema/CompoundPriceSpecification.pm
@@ -59,7 +59,7 @@ A price_component should be one of the following types:
 
 has price_component => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price_component',
     json_ld   => 'priceComponent',
 );
 

--- a/lib/SemanticWeb/Schema/ConsumeAction.pm
+++ b/lib/SemanticWeb/Schema/ConsumeAction.pm
@@ -50,7 +50,7 @@ A action_accessibility_requirement should be one of the following types:
 
 has action_accessibility_requirement => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_action_accessibility_requirement',
     json_ld   => 'actionAccessibilityRequirement',
 );
 
@@ -75,7 +75,7 @@ A expects_acceptance_of should be one of the following types:
 
 has expects_acceptance_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_expects_acceptance_of',
     json_ld   => 'expectsAcceptanceOf',
 );
 

--- a/lib/SemanticWeb/Schema/ContactPoint.pm
+++ b/lib/SemanticWeb/Schema/ContactPoint.pm
@@ -54,7 +54,7 @@ A area_served should be one of the following types:
 
 has area_served => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_area_served',
     json_ld   => 'areaServed',
 );
 
@@ -87,7 +87,7 @@ A available_language should be one of the following types:
 
 has available_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_language',
     json_ld   => 'availableLanguage',
 );
 
@@ -112,7 +112,7 @@ A contact_option should be one of the following types:
 
 has contact_option => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contact_option',
     json_ld   => 'contactOption',
 );
 
@@ -138,7 +138,7 @@ A contact_type should be one of the following types:
 
 has contact_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contact_type',
     json_ld   => 'contactType',
 );
 
@@ -162,7 +162,7 @@ A email should be one of the following types:
 
 has email => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_email',
     json_ld   => 'email',
 );
 
@@ -186,7 +186,7 @@ A fax_number should be one of the following types:
 
 has fax_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_fax_number',
     json_ld   => 'faxNumber',
 );
 
@@ -210,7 +210,7 @@ A hours_available should be one of the following types:
 
 has hours_available => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_hours_available',
     json_ld   => 'hoursAvailable',
 );
 
@@ -239,7 +239,7 @@ A product_supported should be one of the following types:
 
 has product_supported => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_product_supported',
     json_ld   => 'productSupported',
 );
 
@@ -267,7 +267,7 @@ A service_area should be one of the following types:
 
 has service_area => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_service_area',
     json_ld   => 'serviceArea',
 );
 
@@ -291,7 +291,7 @@ A telephone should be one of the following types:
 
 has telephone => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_telephone',
     json_ld   => 'telephone',
 );
 

--- a/lib/SemanticWeb/Schema/CookAction.pm
+++ b/lib/SemanticWeb/Schema/CookAction.pm
@@ -51,7 +51,7 @@ A food_establishment should be one of the following types:
 
 has food_establishment => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_food_establishment',
     json_ld   => 'foodEstablishment',
 );
 
@@ -76,7 +76,7 @@ A food_event should be one of the following types:
 
 has food_event => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_food_event',
     json_ld   => 'foodEvent',
 );
 
@@ -101,7 +101,7 @@ A recipe should be one of the following types:
 
 has recipe => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipe',
     json_ld   => 'recipe',
 );
 

--- a/lib/SemanticWeb/Schema/Corporation.pm
+++ b/lib/SemanticWeb/Schema/Corporation.pm
@@ -52,7 +52,7 @@ A ticker_symbol should be one of the following types:
 
 has ticker_symbol => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ticker_symbol',
     json_ld   => 'tickerSymbol',
 );
 

--- a/lib/SemanticWeb/Schema/Course.pm
+++ b/lib/SemanticWeb/Schema/Course.pm
@@ -60,7 +60,7 @@ A course_code should be one of the following types:
 
 has course_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_course_code',
     json_ld   => 'courseCode',
 );
 
@@ -96,7 +96,7 @@ A course_prerequisites should be one of the following types:
 
 has course_prerequisites => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_course_prerequisites',
     json_ld   => 'coursePrerequisites',
 );
 
@@ -124,7 +124,7 @@ A educational_credential_awarded should be one of the following types:
 
 has educational_credential_awarded => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_educational_credential_awarded',
     json_ld   => 'educationalCredentialAwarded',
 );
 
@@ -149,7 +149,7 @@ A has_course_instance should be one of the following types:
 
 has has_course_instance => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_course_instance',
     json_ld   => 'hasCourseInstance',
 );
 
@@ -177,7 +177,7 @@ A occupational_credential_awarded should be one of the following types:
 
 has occupational_credential_awarded => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_occupational_credential_awarded',
     json_ld   => 'occupationalCredentialAwarded',
 );
 

--- a/lib/SemanticWeb/Schema/CourseInstance.pm
+++ b/lib/SemanticWeb/Schema/CourseInstance.pm
@@ -59,7 +59,7 @@ A course_mode should be one of the following types:
 
 has course_mode => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_course_mode',
     json_ld   => 'courseMode',
 );
 
@@ -86,7 +86,7 @@ A course_workload should be one of the following types:
 
 has course_workload => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_course_workload',
     json_ld   => 'courseWorkload',
 );
 
@@ -116,7 +116,7 @@ A instructor should be one of the following types:
 
 has instructor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_instructor',
     json_ld   => 'instructor',
 );
 

--- a/lib/SemanticWeb/Schema/CreativeWork.pm
+++ b/lib/SemanticWeb/Schema/CreativeWork.pm
@@ -49,7 +49,7 @@ A about should be one of the following types:
 
 has about => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_about',
     json_ld   => 'about',
 );
 
@@ -79,7 +79,7 @@ A abstract should be one of the following types:
 
 has abstract => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_abstract',
     json_ld   => 'abstract',
 );
 
@@ -106,7 +106,7 @@ A access_mode should be one of the following types:
 
 has access_mode => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_access_mode',
     json_ld   => 'accessMode',
 );
 
@@ -132,7 +132,7 @@ A access_mode_sufficient should be one of the following types:
 
 has access_mode_sufficient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_access_mode_sufficient',
     json_ld   => 'accessModeSufficient',
 );
 
@@ -163,7 +163,7 @@ A accessibility_api should be one of the following types:
 
 has accessibility_api => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_accessibility_api',
     json_ld   => 'accessibilityAPI',
 );
 
@@ -194,7 +194,7 @@ A accessibility_control should be one of the following types:
 
 has accessibility_control => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_accessibility_control',
     json_ld   => 'accessibilityControl',
 );
 
@@ -225,7 +225,7 @@ A accessibility_feature should be one of the following types:
 
 has accessibility_feature => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_accessibility_feature',
     json_ld   => 'accessibilityFeature',
 );
 
@@ -256,7 +256,7 @@ A accessibility_hazard should be one of the following types:
 
 has accessibility_hazard => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_accessibility_hazard',
     json_ld   => 'accessibilityHazard',
 );
 
@@ -284,7 +284,7 @@ A accessibility_summary should be one of the following types:
 
 has accessibility_summary => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_accessibility_summary',
     json_ld   => 'accessibilitySummary',
 );
 
@@ -308,7 +308,7 @@ A accountable_person should be one of the following types:
 
 has accountable_person => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_accountable_person',
     json_ld   => 'accountablePerson',
 );
 
@@ -333,7 +333,7 @@ A aggregate_rating should be one of the following types:
 
 has aggregate_rating => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_aggregate_rating',
     json_ld   => 'aggregateRating',
 );
 
@@ -357,7 +357,7 @@ A alternative_headline should be one of the following types:
 
 has alternative_headline => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_alternative_headline',
     json_ld   => 'alternativeHeadline',
 );
 
@@ -382,7 +382,7 @@ A associated_media should be one of the following types:
 
 has associated_media => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_associated_media',
     json_ld   => 'associatedMedia',
 );
 
@@ -406,7 +406,7 @@ A audience should be one of the following types:
 
 has audience => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_audience',
     json_ld   => 'audience',
 );
 
@@ -432,7 +432,7 @@ A audio should be one of the following types:
 
 has audio => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_audio',
     json_ld   => 'audio',
 );
 
@@ -460,7 +460,7 @@ A author should be one of the following types:
 
 has author => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_author',
     json_ld   => 'author',
 );
 
@@ -484,7 +484,7 @@ A award should be one of the following types:
 
 has award => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_award',
     json_ld   => 'award',
 );
 
@@ -508,7 +508,7 @@ A awards should be one of the following types:
 
 has awards => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_awards',
     json_ld   => 'awards',
 );
 
@@ -532,7 +532,7 @@ A character should be one of the following types:
 
 has character => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_character',
     json_ld   => 'character',
 );
 
@@ -559,7 +559,7 @@ A citation should be one of the following types:
 
 has citation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_citation',
     json_ld   => 'citation',
 );
 
@@ -583,7 +583,7 @@ A comment should be one of the following types:
 
 has comment => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_comment',
     json_ld   => 'comment',
 );
 
@@ -609,7 +609,7 @@ A comment_count should be one of the following types:
 
 has comment_count => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_comment_count',
     json_ld   => 'commentCount',
 );
 
@@ -646,7 +646,7 @@ A conditions_of_access should be one of the following types:
 
 has conditions_of_access => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_conditions_of_access',
     json_ld   => 'conditionsOfAccess',
 );
 
@@ -671,7 +671,7 @@ A content_location should be one of the following types:
 
 has content_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_content_location',
     json_ld   => 'contentLocation',
 );
 
@@ -697,7 +697,7 @@ A content_rating should be one of the following types:
 
 has content_rating => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_content_rating',
     json_ld   => 'contentRating',
 );
 
@@ -722,7 +722,7 @@ A content_reference_time should be one of the following types:
 
 has content_reference_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_content_reference_time',
     json_ld   => 'contentReferenceTime',
 );
 
@@ -748,7 +748,7 @@ A contributor should be one of the following types:
 
 has contributor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contributor',
     json_ld   => 'contributor',
 );
 
@@ -774,7 +774,7 @@ A copyright_holder should be one of the following types:
 
 has copyright_holder => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_copyright_holder',
     json_ld   => 'copyrightHolder',
 );
 
@@ -799,7 +799,7 @@ A copyright_year should be one of the following types:
 
 has copyright_year => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_copyright_year',
     json_ld   => 'copyrightYear',
 );
 
@@ -833,7 +833,7 @@ A correction should be one of the following types:
 
 has correction => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_correction',
     json_ld   => 'correction',
 );
 
@@ -861,7 +861,7 @@ A creative_work_status should be one of the following types:
 
 has creative_work_status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_creative_work_status',
     json_ld   => 'creativeWorkStatus',
 );
 
@@ -888,7 +888,7 @@ A creator should be one of the following types:
 
 has creator => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_creator',
     json_ld   => 'creator',
 );
 
@@ -913,7 +913,7 @@ A date_created should be one of the following types:
 
 has date_created => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_date_created',
     json_ld   => 'dateCreated',
 );
 
@@ -938,7 +938,7 @@ A date_modified should be one of the following types:
 
 has date_modified => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_date_modified',
     json_ld   => 'dateModified',
 );
 
@@ -962,7 +962,7 @@ A date_published should be one of the following types:
 
 has date_published => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_date_published',
     json_ld   => 'datePublished',
 );
 
@@ -986,7 +986,7 @@ A discussion_url should be one of the following types:
 
 has discussion_url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_discussion_url',
     json_ld   => 'discussionUrl',
 );
 
@@ -1010,7 +1010,7 @@ A editor should be one of the following types:
 
 has editor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_editor',
     json_ld   => 'editor',
 );
 
@@ -1034,7 +1034,7 @@ A educational_alignment should be one of the following types:
 
 has educational_alignment => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_educational_alignment',
     json_ld   => 'educationalAlignment',
 );
 
@@ -1059,7 +1059,7 @@ A educational_use should be one of the following types:
 
 has educational_use => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_educational_use',
     json_ld   => 'educationalUse',
 );
 
@@ -1084,7 +1084,7 @@ A encoding should be one of the following types:
 
 has encoding => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_encoding',
     json_ld   => 'encoding',
 );
 
@@ -1126,7 +1126,7 @@ A encoding_format should be one of the following types:
 
 has encoding_format => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_encoding_format',
     json_ld   => 'encodingFormat',
 );
 
@@ -1150,7 +1150,7 @@ A encodings should be one of the following types:
 
 has encodings => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_encodings',
     json_ld   => 'encodings',
 );
 
@@ -1175,7 +1175,7 @@ A example_of_work should be one of the following types:
 
 has example_of_work => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_example_of_work',
     json_ld   => 'exampleOfWork',
 );
 
@@ -1210,7 +1210,7 @@ A expires should be one of the following types:
 
 has expires => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_expires',
     json_ld   => 'expires',
 );
 
@@ -1245,7 +1245,7 @@ A file_format should be one of the following types:
 
 has file_format => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_file_format',
     json_ld   => 'fileFormat',
 );
 
@@ -1272,7 +1272,7 @@ A funder should be one of the following types:
 
 has funder => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_funder',
     json_ld   => 'funder',
 );
 
@@ -1296,7 +1296,7 @@ A genre should be one of the following types:
 
 has genre => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_genre',
     json_ld   => 'genre',
 );
 
@@ -1321,7 +1321,7 @@ A has_part should be one of the following types:
 
 has has_part => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_part',
     json_ld   => 'hasPart',
 );
 
@@ -1345,7 +1345,7 @@ A headline should be one of the following types:
 
 has headline => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_headline',
     json_ld   => 'headline',
 );
 
@@ -1379,7 +1379,7 @@ A in_language should be one of the following types:
 
 has in_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_in_language',
     json_ld   => 'inLanguage',
 );
 
@@ -1405,7 +1405,7 @@ A interaction_statistic should be one of the following types:
 
 has interaction_statistic => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_interaction_statistic',
     json_ld   => 'interactionStatistic',
 );
 
@@ -1430,7 +1430,7 @@ A interactivity_type should be one of the following types:
 
 has interactivity_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_interactivity_type',
     json_ld   => 'interactivityType',
 );
 
@@ -1454,7 +1454,7 @@ A is_accessible_for_free should be one of the following types:
 
 has is_accessible_for_free => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_accessible_for_free',
     json_ld   => 'isAccessibleForFree',
 );
 
@@ -1483,7 +1483,7 @@ A is_based_on should be one of the following types:
 
 has is_based_on => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_based_on',
     json_ld   => 'isBasedOn',
 );
 
@@ -1513,7 +1513,7 @@ A is_based_on_url should be one of the following types:
 
 has is_based_on_url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_based_on_url',
     json_ld   => 'isBasedOnUrl',
 );
 
@@ -1537,7 +1537,7 @@ A is_family_friendly should be one of the following types:
 
 has is_family_friendly => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_family_friendly',
     json_ld   => 'isFamilyFriendly',
 );
 
@@ -1562,7 +1562,7 @@ A is_part_of should be one of the following types:
 
 has is_part_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_part_of',
     json_ld   => 'isPartOf',
 );
 
@@ -1587,7 +1587,7 @@ A keywords should be one of the following types:
 
 has keywords => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_keywords',
     json_ld   => 'keywords',
 );
 
@@ -1612,7 +1612,7 @@ A learning_resource_type should be one of the following types:
 
 has learning_resource_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_learning_resource_type',
     json_ld   => 'learningResourceType',
 );
 
@@ -1639,7 +1639,7 @@ A license should be one of the following types:
 
 has license => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_license',
     json_ld   => 'license',
 );
 
@@ -1664,7 +1664,7 @@ A location_created should be one of the following types:
 
 has location_created => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_location_created',
     json_ld   => 'locationCreated',
 );
 
@@ -1688,7 +1688,7 @@ A main_entity should be one of the following types:
 
 has main_entity => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_main_entity',
     json_ld   => 'mainEntity',
 );
 
@@ -1714,7 +1714,7 @@ A material should be one of the following types:
 
 has material => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_material',
     json_ld   => 'material',
 );
 
@@ -1741,7 +1741,7 @@ A material_extent should be one of the following types:
 
 has material_extent => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_material_extent',
     json_ld   => 'materialExtent',
 );
 
@@ -1766,7 +1766,7 @@ A mentions should be one of the following types:
 
 has mentions => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_mentions',
     json_ld   => 'mentions',
 );
 
@@ -1792,7 +1792,7 @@ A offers should be one of the following types:
 
 has offers => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_offers',
     json_ld   => 'offers',
 );
 
@@ -1818,7 +1818,7 @@ A position should be one of the following types:
 
 has position => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_position',
     json_ld   => 'position',
 );
 
@@ -1845,7 +1845,7 @@ A producer should be one of the following types:
 
 has producer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_producer',
     json_ld   => 'producer',
 );
 
@@ -1873,7 +1873,7 @@ A provider should be one of the following types:
 
 has provider => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_provider',
     json_ld   => 'provider',
 );
 
@@ -1897,7 +1897,7 @@ A publication should be one of the following types:
 
 has publication => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_publication',
     json_ld   => 'publication',
 );
 
@@ -1923,7 +1923,7 @@ A publisher should be one of the following types:
 
 has publisher => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_publisher',
     json_ld   => 'publisher',
 );
 
@@ -1947,7 +1947,7 @@ A publisher_imprint should be one of the following types:
 
 has publisher_imprint => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_publisher_imprint',
     json_ld   => 'publisherImprint',
 );
 
@@ -1992,7 +1992,7 @@ A publishing_principles should be one of the following types:
 
 has publishing_principles => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_publishing_principles',
     json_ld   => 'publishingPrinciples',
 );
 
@@ -2017,7 +2017,7 @@ A recorded_at should be one of the following types:
 
 has recorded_at => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recorded_at',
     json_ld   => 'recordedAt',
 );
 
@@ -2041,7 +2041,7 @@ A released_event should be one of the following types:
 
 has released_event => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_released_event',
     json_ld   => 'releasedEvent',
 );
 
@@ -2065,7 +2065,7 @@ A review should be one of the following types:
 
 has review => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_review',
     json_ld   => 'review',
 );
 
@@ -2089,7 +2089,7 @@ A reviews should be one of the following types:
 
 has reviews => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_reviews',
     json_ld   => 'reviews',
 );
 
@@ -2116,7 +2116,7 @@ A schema_version should be one of the following types:
 
 has schema_version => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_schema_version',
     json_ld   => 'schemaVersion',
 );
 
@@ -2146,7 +2146,7 @@ A sd_date_published should be one of the following types:
 
 has sd_date_published => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sd_date_published',
     json_ld   => 'sdDatePublished',
 );
 
@@ -2173,7 +2173,7 @@ A sd_license should be one of the following types:
 
 has sd_license => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sd_license',
     json_ld   => 'sdLicense',
 );
 
@@ -2210,7 +2210,7 @@ A sd_publisher should be one of the following types:
 
 has sd_publisher => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sd_publisher',
     json_ld   => 'sdPublisher',
 );
 
@@ -2234,7 +2234,7 @@ A source_organization should be one of the following types:
 
 has source_organization => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_source_organization',
     json_ld   => 'sourceOrganization',
 );
 
@@ -2269,7 +2269,7 @@ A spatial should be one of the following types:
 
 has spatial => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_spatial',
     json_ld   => 'spatial',
 );
 
@@ -2298,7 +2298,7 @@ A spatial_coverage should be one of the following types:
 
 has spatial_coverage => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_spatial_coverage',
     json_ld   => 'spatialCoverage',
 );
 
@@ -2326,7 +2326,7 @@ A sponsor should be one of the following types:
 
 has sponsor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sponsor',
     json_ld   => 'sponsor',
 );
 
@@ -2361,7 +2361,7 @@ A temporal should be one of the following types:
 
 has temporal => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_temporal',
     json_ld   => 'temporal',
 );
 
@@ -2404,7 +2404,7 @@ A temporal_coverage should be one of the following types:
 
 has temporal_coverage => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_temporal_coverage',
     json_ld   => 'temporalCoverage',
 );
 
@@ -2428,7 +2428,7 @@ A text should be one of the following types:
 
 has text => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_text',
     json_ld   => 'text',
 );
 
@@ -2452,7 +2452,7 @@ A thumbnail_url should be one of the following types:
 
 has thumbnail_url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_thumbnail_url',
     json_ld   => 'thumbnailUrl',
 );
 
@@ -2477,7 +2477,7 @@ A time_required should be one of the following types:
 
 has time_required => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_time_required',
     json_ld   => 'timeRequired',
 );
 
@@ -2502,7 +2502,7 @@ A translation_of_work should be one of the following types:
 
 has translation_of_work => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_translation_of_work',
     json_ld   => 'translationOfWork',
 );
 
@@ -2530,7 +2530,7 @@ A translator should be one of the following types:
 
 has translator => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_translator',
     json_ld   => 'translator',
 );
 
@@ -2554,7 +2554,7 @@ A typical_age_range should be one of the following types:
 
 has typical_age_range => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_typical_age_range',
     json_ld   => 'typicalAgeRange',
 );
 
@@ -2580,7 +2580,7 @@ A version should be one of the following types:
 
 has version => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_version',
     json_ld   => 'version',
 );
 
@@ -2606,7 +2606,7 @@ A video should be one of the following types:
 
 has video => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_video',
     json_ld   => 'video',
 );
 
@@ -2631,7 +2631,7 @@ A work_example should be one of the following types:
 
 has work_example => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_work_example',
     json_ld   => 'workExample',
 );
 
@@ -2658,7 +2658,7 @@ A work_translation should be one of the following types:
 
 has work_translation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_work_translation',
     json_ld   => 'workTranslation',
 );
 

--- a/lib/SemanticWeb/Schema/CreativeWorkSeason.pm
+++ b/lib/SemanticWeb/Schema/CreativeWorkSeason.pm
@@ -50,7 +50,7 @@ A actor should be one of the following types:
 
 has actor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actor',
     json_ld   => 'actor',
 );
 
@@ -76,7 +76,7 @@ A director should be one of the following types:
 
 has director => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_director',
     json_ld   => 'director',
 );
 
@@ -105,7 +105,7 @@ A end_date should be one of the following types:
 
 has end_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_end_date',
     json_ld   => 'endDate',
 );
 
@@ -129,7 +129,7 @@ A episode should be one of the following types:
 
 has episode => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_episode',
     json_ld   => 'episode',
 );
 
@@ -153,7 +153,7 @@ A episodes should be one of the following types:
 
 has episodes => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_episodes',
     json_ld   => 'episodes',
 );
 
@@ -177,7 +177,7 @@ A number_of_episodes should be one of the following types:
 
 has number_of_episodes => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_episodes',
     json_ld   => 'numberOfEpisodes',
 );
 
@@ -201,7 +201,7 @@ A part_of_series should be one of the following types:
 
 has part_of_series => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_part_of_series',
     json_ld   => 'partOfSeries',
 );
 
@@ -226,7 +226,7 @@ A production_company should be one of the following types:
 
 has production_company => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_production_company',
     json_ld   => 'productionCompany',
 );
 
@@ -252,7 +252,7 @@ A season_number should be one of the following types:
 
 has season_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_season_number',
     json_ld   => 'seasonNumber',
 );
 
@@ -281,7 +281,7 @@ A start_date should be one of the following types:
 
 has start_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_start_date',
     json_ld   => 'startDate',
 );
 
@@ -305,7 +305,7 @@ A trailer should be one of the following types:
 
 has trailer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_trailer',
     json_ld   => 'trailer',
 );
 

--- a/lib/SemanticWeb/Schema/CreativeWorkSeries.pm
+++ b/lib/SemanticWeb/Schema/CreativeWorkSeries.pm
@@ -79,7 +79,7 @@ A end_date should be one of the following types:
 
 has end_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_end_date',
     json_ld   => 'endDate',
 );
 
@@ -105,7 +105,7 @@ A issn should be one of the following types:
 
 has issn => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_issn',
     json_ld   => 'issn',
 );
 
@@ -134,7 +134,7 @@ A start_date should be one of the following types:
 
 has start_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_start_date',
     json_ld   => 'startDate',
 );
 

--- a/lib/SemanticWeb/Schema/CreditCard.pm
+++ b/lib/SemanticWeb/Schema/CreditCard.pm
@@ -63,7 +63,7 @@ A monthly_minimum_repayment_amount should be one of the following types:
 
 has monthly_minimum_repayment_amount => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_monthly_minimum_repayment_amount',
     json_ld   => 'monthlyMinimumRepaymentAmount',
 );
 

--- a/lib/SemanticWeb/Schema/DDxElement.pm
+++ b/lib/SemanticWeb/Schema/DDxElement.pm
@@ -51,7 +51,7 @@ A diagnosis should be one of the following types:
 
 has diagnosis => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_diagnosis',
     json_ld   => 'diagnosis',
 );
 
@@ -76,7 +76,7 @@ A distinguishing_sign should be one of the following types:
 
 has distinguishing_sign => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_distinguishing_sign',
     json_ld   => 'distinguishingSign',
 );
 

--- a/lib/SemanticWeb/Schema/DataCatalog.pm
+++ b/lib/SemanticWeb/Schema/DataCatalog.pm
@@ -48,7 +48,7 @@ A dataset should be one of the following types:
 
 has dataset => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_dataset',
     json_ld   => 'dataset',
 );
 
@@ -103,7 +103,7 @@ A measurement_technique should be one of the following types:
 
 has measurement_technique => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_measurement_technique',
     json_ld   => 'measurementTechnique',
 );
 

--- a/lib/SemanticWeb/Schema/DataDownload.pm
+++ b/lib/SemanticWeb/Schema/DataDownload.pm
@@ -79,7 +79,7 @@ A measurement_technique should be one of the following types:
 
 has measurement_technique => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_measurement_technique',
     json_ld   => 'measurementTechnique',
 );
 

--- a/lib/SemanticWeb/Schema/DataFeed.pm
+++ b/lib/SemanticWeb/Schema/DataFeed.pm
@@ -53,7 +53,7 @@ A data_feed_element should be one of the following types:
 
 has data_feed_element => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_data_feed_element',
     json_ld   => 'dataFeedElement',
 );
 

--- a/lib/SemanticWeb/Schema/DataFeedItem.pm
+++ b/lib/SemanticWeb/Schema/DataFeedItem.pm
@@ -49,7 +49,7 @@ A date_created should be one of the following types:
 
 has date_created => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_date_created',
     json_ld   => 'dateCreated',
 );
 
@@ -73,7 +73,7 @@ A date_deleted should be one of the following types:
 
 has date_deleted => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_date_deleted',
     json_ld   => 'dateDeleted',
 );
 
@@ -98,7 +98,7 @@ A date_modified should be one of the following types:
 
 has date_modified => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_date_modified',
     json_ld   => 'dateModified',
 );
 
@@ -123,7 +123,7 @@ A item should be one of the following types:
 
 has item => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_item',
     json_ld   => 'item',
 );
 

--- a/lib/SemanticWeb/Schema/Dataset.pm
+++ b/lib/SemanticWeb/Schema/Dataset.pm
@@ -48,7 +48,7 @@ A catalog should be one of the following types:
 
 has catalog => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_catalog',
     json_ld   => 'catalog',
 );
 
@@ -73,7 +73,7 @@ A dataset_time_interval should be one of the following types:
 
 has dataset_time_interval => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_dataset_time_interval',
     json_ld   => 'datasetTimeInterval',
 );
 
@@ -98,7 +98,7 @@ A distribution should be one of the following types:
 
 has distribution => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_distribution',
     json_ld   => 'distribution',
 );
 
@@ -123,7 +123,7 @@ A included_data_catalog should be one of the following types:
 
 has included_data_catalog => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_included_data_catalog',
     json_ld   => 'includedDataCatalog',
 );
 
@@ -147,7 +147,7 @@ A included_in_data_catalog should be one of the following types:
 
 has included_in_data_catalog => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_included_in_data_catalog',
     json_ld   => 'includedInDataCatalog',
 );
 
@@ -173,7 +173,7 @@ A issn should be one of the following types:
 
 has issn => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_issn',
     json_ld   => 'issn',
 );
 
@@ -228,7 +228,7 @@ A measurement_technique should be one of the following types:
 
 has measurement_technique => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_measurement_technique',
     json_ld   => 'measurementTechnique',
 );
 
@@ -256,7 +256,7 @@ A variable_measured should be one of the following types:
 
 has variable_measured => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_variable_measured',
     json_ld   => 'variableMeasured',
 );
 

--- a/lib/SemanticWeb/Schema/DatedMoneySpecification.pm
+++ b/lib/SemanticWeb/Schema/DatedMoneySpecification.pm
@@ -59,7 +59,7 @@ A amount should be one of the following types:
 
 has amount => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_amount',
     json_ld   => 'amount',
 );
 
@@ -94,7 +94,7 @@ A currency should be one of the following types:
 
 has currency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_currency',
     json_ld   => 'currency',
 );
 
@@ -123,7 +123,7 @@ A end_date should be one of the following types:
 
 has end_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_end_date',
     json_ld   => 'endDate',
 );
 
@@ -152,7 +152,7 @@ A start_date should be one of the following types:
 
 has start_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_start_date',
     json_ld   => 'startDate',
 );
 

--- a/lib/SemanticWeb/Schema/DefinedTerm.pm
+++ b/lib/SemanticWeb/Schema/DefinedTerm.pm
@@ -60,7 +60,7 @@ A in_defined_term_set should be one of the following types:
 
 has in_defined_term_set => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_in_defined_term_set',
     json_ld   => 'inDefinedTermSet',
 );
 
@@ -91,7 +91,7 @@ A term_code should be one of the following types:
 
 has term_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_term_code',
     json_ld   => 'termCode',
 );
 

--- a/lib/SemanticWeb/Schema/DefinedTermSet.pm
+++ b/lib/SemanticWeb/Schema/DefinedTermSet.pm
@@ -49,7 +49,7 @@ A has_defined_term should be one of the following types:
 
 has has_defined_term => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_defined_term',
     json_ld   => 'hasDefinedTerm',
 );
 

--- a/lib/SemanticWeb/Schema/DeliveryChargeSpecification.pm
+++ b/lib/SemanticWeb/Schema/DeliveryChargeSpecification.pm
@@ -49,7 +49,7 @@ A applies_to_delivery_method should be one of the following types:
 
 has applies_to_delivery_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_applies_to_delivery_method',
     json_ld   => 'appliesToDeliveryMethod',
 );
 
@@ -79,7 +79,7 @@ A area_served should be one of the following types:
 
 has area_served => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_area_served',
     json_ld   => 'areaServed',
 );
 
@@ -115,7 +115,7 @@ A eligible_region should be one of the following types:
 
 has eligible_region => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_eligible_region',
     json_ld   => 'eligibleRegion',
 );
 
@@ -151,7 +151,7 @@ A ineligible_region should be one of the following types:
 
 has ineligible_region => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ineligible_region',
     json_ld   => 'ineligibleRegion',
 );
 

--- a/lib/SemanticWeb/Schema/DeliveryEvent.pm
+++ b/lib/SemanticWeb/Schema/DeliveryEvent.pm
@@ -48,7 +48,7 @@ A access_code should be one of the following types:
 
 has access_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_access_code',
     json_ld   => 'accessCode',
 );
 
@@ -72,7 +72,7 @@ A available_from should be one of the following types:
 
 has available_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_from',
     json_ld   => 'availableFrom',
 );
 
@@ -96,7 +96,7 @@ A available_through should be one of the following types:
 
 has available_through => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_through',
     json_ld   => 'availableThrough',
 );
 
@@ -120,7 +120,7 @@ A has_delivery_method should be one of the following types:
 
 has has_delivery_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_delivery_method',
     json_ld   => 'hasDeliveryMethod',
 );
 

--- a/lib/SemanticWeb/Schema/Demand.pm
+++ b/lib/SemanticWeb/Schema/Demand.pm
@@ -53,7 +53,7 @@ A accepted_payment_method should be one of the following types:
 
 has accepted_payment_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_accepted_payment_method',
     json_ld   => 'acceptedPaymentMethod',
 );
 
@@ -78,7 +78,7 @@ A advance_booking_requirement should be one of the following types:
 
 has advance_booking_requirement => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_advance_booking_requirement',
     json_ld   => 'advanceBookingRequirement',
 );
 
@@ -108,7 +108,7 @@ A area_served should be one of the following types:
 
 has area_served => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_area_served',
     json_ld   => 'areaServed',
 );
 
@@ -133,7 +133,7 @@ A availability should be one of the following types:
 
 has availability => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_availability',
     json_ld   => 'availability',
 );
 
@@ -158,7 +158,7 @@ A availability_ends should be one of the following types:
 
 has availability_ends => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_availability_ends',
     json_ld   => 'availabilityEnds',
 );
 
@@ -183,7 +183,7 @@ A availability_starts should be one of the following types:
 
 has availability_starts => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_availability_starts',
     json_ld   => 'availabilityStarts',
 );
 
@@ -207,7 +207,7 @@ A available_at_or_from should be one of the following types:
 
 has available_at_or_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_at_or_from',
     json_ld   => 'availableAtOrFrom',
 );
 
@@ -231,7 +231,7 @@ A available_delivery_method should be one of the following types:
 
 has available_delivery_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_delivery_method',
     json_ld   => 'availableDeliveryMethod',
 );
 
@@ -257,7 +257,7 @@ A business_function should be one of the following types:
 
 has business_function => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_business_function',
     json_ld   => 'businessFunction',
 );
 
@@ -283,7 +283,7 @@ A delivery_lead_time should be one of the following types:
 
 has delivery_lead_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_delivery_lead_time',
     json_ld   => 'deliveryLeadTime',
 );
 
@@ -307,7 +307,7 @@ A eligible_customer_type should be one of the following types:
 
 has eligible_customer_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_eligible_customer_type',
     json_ld   => 'eligibleCustomerType',
 );
 
@@ -331,7 +331,7 @@ A eligible_duration should be one of the following types:
 
 has eligible_duration => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_eligible_duration',
     json_ld   => 'eligibleDuration',
 );
 
@@ -357,7 +357,7 @@ A eligible_quantity should be one of the following types:
 
 has eligible_quantity => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_eligible_quantity',
     json_ld   => 'eligibleQuantity',
 );
 
@@ -393,7 +393,7 @@ A eligible_region should be one of the following types:
 
 has eligible_region => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_eligible_region',
     json_ld   => 'eligibleRegion',
 );
 
@@ -420,7 +420,7 @@ A eligible_transaction_volume should be one of the following types:
 
 has eligible_transaction_volume => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_eligible_transaction_volume',
     json_ld   => 'eligibleTransactionVolume',
 );
 
@@ -469,7 +469,7 @@ A gtin should be one of the following types:
 
 has gtin => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin',
     json_ld   => 'gtin',
 );
 
@@ -502,7 +502,7 @@ A gtin12 should be one of the following types:
 
 has gtin12 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin12',
     json_ld   => 'gtin12',
 );
 
@@ -535,7 +535,7 @@ A gtin13 should be one of the following types:
 
 has gtin13 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin13',
     json_ld   => 'gtin13',
 );
 
@@ -565,7 +565,7 @@ A gtin14 should be one of the following types:
 
 has gtin14 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin14',
     json_ld   => 'gtin14',
 );
 
@@ -598,7 +598,7 @@ A gtin8 should be one of the following types:
 
 has gtin8 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin8',
     json_ld   => 'gtin8',
 );
 
@@ -623,7 +623,7 @@ A includes_object should be one of the following types:
 
 has includes_object => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_includes_object',
     json_ld   => 'includesObject',
 );
 
@@ -659,7 +659,7 @@ A ineligible_region should be one of the following types:
 
 has ineligible_region => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ineligible_region',
     json_ld   => 'ineligibleRegion',
 );
 
@@ -683,7 +683,7 @@ A inventory_level should be one of the following types:
 
 has inventory_level => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_inventory_level',
     json_ld   => 'inventoryLevel',
 );
 
@@ -709,7 +709,7 @@ A item_condition should be one of the following types:
 
 has item_condition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_item_condition',
     json_ld   => 'itemCondition',
 );
 
@@ -735,7 +735,7 @@ A item_offered should be one of the following types:
 
 has item_offered => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_item_offered',
     json_ld   => 'itemOffered',
 );
 
@@ -760,7 +760,7 @@ A mpn should be one of the following types:
 
 has mpn => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_mpn',
     json_ld   => 'mpn',
 );
 
@@ -785,7 +785,7 @@ A price_specification should be one of the following types:
 
 has price_specification => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price_specification',
     json_ld   => 'priceSpecification',
 );
 
@@ -812,7 +812,7 @@ A seller should be one of the following types:
 
 has seller => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seller',
     json_ld   => 'seller',
 );
 
@@ -838,7 +838,7 @@ A serial_number should be one of the following types:
 
 has serial_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_serial_number',
     json_ld   => 'serialNumber',
 );
 
@@ -863,7 +863,7 @@ A sku should be one of the following types:
 
 has sku => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sku',
     json_ld   => 'sku',
 );
 
@@ -887,7 +887,7 @@ A valid_from should be one of the following types:
 
 has valid_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_from',
     json_ld   => 'validFrom',
 );
 
@@ -912,7 +912,7 @@ A valid_through should be one of the following types:
 
 has valid_through => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_through',
     json_ld   => 'validThrough',
 );
 
@@ -936,7 +936,7 @@ A warranty should be one of the following types:
 
 has warranty => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_warranty',
     json_ld   => 'warranty',
 );
 

--- a/lib/SemanticWeb/Schema/DiagnosticLab.pm
+++ b/lib/SemanticWeb/Schema/DiagnosticLab.pm
@@ -48,7 +48,7 @@ A available_test should be one of the following types:
 
 has available_test => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_test',
     json_ld   => 'availableTest',
 );
 

--- a/lib/SemanticWeb/Schema/Diet.pm
+++ b/lib/SemanticWeb/Schema/Diet.pm
@@ -52,7 +52,7 @@ A diet_features should be one of the following types:
 
 has diet_features => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_diet_features',
     json_ld   => 'dietFeatures',
 );
 
@@ -78,7 +78,7 @@ A endorsers should be one of the following types:
 
 has endorsers => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_endorsers',
     json_ld   => 'endorsers',
 );
 
@@ -102,7 +102,7 @@ A expert_considerations should be one of the following types:
 
 has expert_considerations => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_expert_considerations',
     json_ld   => 'expertConsiderations',
 );
 
@@ -128,7 +128,7 @@ A overview should be one of the following types:
 
 has overview => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_overview',
     json_ld   => 'overview',
 );
 
@@ -152,7 +152,7 @@ A physiological_benefits should be one of the following types:
 
 has physiological_benefits => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_physiological_benefits',
     json_ld   => 'physiologicalBenefits',
 );
 
@@ -176,7 +176,7 @@ A risks should be one of the following types:
 
 has risks => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_risks',
     json_ld   => 'risks',
 );
 

--- a/lib/SemanticWeb/Schema/DietarySupplement.pm
+++ b/lib/SemanticWeb/Schema/DietarySupplement.pm
@@ -52,7 +52,7 @@ A active_ingredient should be one of the following types:
 
 has active_ingredient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_active_ingredient',
     json_ld   => 'activeIngredient',
 );
 
@@ -78,7 +78,7 @@ A background should be one of the following types:
 
 has background => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_background',
     json_ld   => 'background',
 );
 
@@ -102,7 +102,7 @@ A is_proprietary should be one of the following types:
 
 has is_proprietary => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_proprietary',
     json_ld   => 'isProprietary',
 );
 
@@ -131,7 +131,7 @@ A legal_status should be one of the following types:
 
 has legal_status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legal_status',
     json_ld   => 'legalStatus',
 );
 
@@ -155,7 +155,7 @@ A manufacturer should be one of the following types:
 
 has manufacturer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_manufacturer',
     json_ld   => 'manufacturer',
 );
 
@@ -180,7 +180,7 @@ A maximum_intake should be one of the following types:
 
 has maximum_intake => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_maximum_intake',
     json_ld   => 'maximumIntake',
 );
 
@@ -205,7 +205,7 @@ A mechanism_of_action should be one of the following types:
 
 has mechanism_of_action => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_mechanism_of_action',
     json_ld   => 'mechanismOfAction',
 );
 
@@ -229,7 +229,7 @@ A non_proprietary_name should be one of the following types:
 
 has non_proprietary_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_non_proprietary_name',
     json_ld   => 'nonProprietaryName',
 );
 
@@ -254,7 +254,7 @@ A proprietary_name should be one of the following types:
 
 has proprietary_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_proprietary_name',
     json_ld   => 'proprietaryName',
 );
 
@@ -279,7 +279,7 @@ A recommended_intake should be one of the following types:
 
 has recommended_intake => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recommended_intake',
     json_ld   => 'recommendedIntake',
 );
 
@@ -305,7 +305,7 @@ A safety_consideration should be one of the following types:
 
 has safety_consideration => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_safety_consideration',
     json_ld   => 'safetyConsideration',
 );
 
@@ -330,7 +330,7 @@ A target_population should be one of the following types:
 
 has target_population => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_target_population',
     json_ld   => 'targetPopulation',
 );
 

--- a/lib/SemanticWeb/Schema/DigitalDocument.pm
+++ b/lib/SemanticWeb/Schema/DigitalDocument.pm
@@ -50,7 +50,7 @@ A has_digital_document_permission should be one of the following types:
 
 has has_digital_document_permission => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_digital_document_permission',
     json_ld   => 'hasDigitalDocumentPermission',
 );
 

--- a/lib/SemanticWeb/Schema/DigitalDocumentPermission.pm
+++ b/lib/SemanticWeb/Schema/DigitalDocumentPermission.pm
@@ -55,7 +55,7 @@ A grantee should be one of the following types:
 
 has grantee => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_grantee',
     json_ld   => 'grantee',
 );
 
@@ -79,7 +79,7 @@ A permission_type should be one of the following types:
 
 has permission_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_permission_type',
     json_ld   => 'permissionType',
 );
 

--- a/lib/SemanticWeb/Schema/DonateAction.pm
+++ b/lib/SemanticWeb/Schema/DonateAction.pm
@@ -56,7 +56,7 @@ A recipient should be one of the following types:
 
 has recipient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipient',
     json_ld   => 'recipient',
 );
 

--- a/lib/SemanticWeb/Schema/DoseSchedule.pm
+++ b/lib/SemanticWeb/Schema/DoseSchedule.pm
@@ -48,7 +48,7 @@ A dose_unit should be one of the following types:
 
 has dose_unit => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_dose_unit',
     json_ld   => 'doseUnit',
 );
 
@@ -74,7 +74,7 @@ A dose_value should be one of the following types:
 
 has dose_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_dose_value',
     json_ld   => 'doseValue',
 );
 
@@ -98,7 +98,7 @@ A frequency should be one of the following types:
 
 has frequency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_frequency',
     json_ld   => 'frequency',
 );
 
@@ -123,7 +123,7 @@ A target_population should be one of the following types:
 
 has target_population => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_target_population',
     json_ld   => 'targetPopulation',
 );
 

--- a/lib/SemanticWeb/Schema/Drug.pm
+++ b/lib/SemanticWeb/Schema/Drug.pm
@@ -52,7 +52,7 @@ A active_ingredient should be one of the following types:
 
 has active_ingredient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_active_ingredient',
     json_ld   => 'activeIngredient',
 );
 
@@ -76,7 +76,7 @@ A administration_route should be one of the following types:
 
 has administration_route => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_administration_route',
     json_ld   => 'administrationRoute',
 );
 
@@ -101,7 +101,7 @@ A alcohol_warning should be one of the following types:
 
 has alcohol_warning => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_alcohol_warning',
     json_ld   => 'alcoholWarning',
 );
 
@@ -125,7 +125,7 @@ A available_strength should be one of the following types:
 
 has available_strength => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_strength',
     json_ld   => 'availableStrength',
 );
 
@@ -150,7 +150,7 @@ A breastfeeding_warning should be one of the following types:
 
 has breastfeeding_warning => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_breastfeeding_warning',
     json_ld   => 'breastfeedingWarning',
 );
 
@@ -176,7 +176,7 @@ A clincal_pharmacology should be one of the following types:
 
 has clincal_pharmacology => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_clincal_pharmacology',
     json_ld   => 'clincalPharmacology',
 );
 
@@ -202,7 +202,7 @@ A clinical_pharmacology should be one of the following types:
 
 has clinical_pharmacology => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_clinical_pharmacology',
     json_ld   => 'clinicalPharmacology',
 );
 
@@ -226,7 +226,7 @@ A cost should be one of the following types:
 
 has cost => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cost',
     json_ld   => 'cost',
 );
 
@@ -251,7 +251,7 @@ A dosage_form should be one of the following types:
 
 has dosage_form => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_dosage_form',
     json_ld   => 'dosageForm',
 );
 
@@ -276,7 +276,7 @@ A dose_schedule should be one of the following types:
 
 has dose_schedule => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_dose_schedule',
     json_ld   => 'doseSchedule',
 );
 
@@ -300,7 +300,7 @@ A drug_class should be one of the following types:
 
 has drug_class => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_drug_class',
     json_ld   => 'drugClass',
 );
 
@@ -324,7 +324,7 @@ A drug_unit should be one of the following types:
 
 has drug_unit => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_drug_unit',
     json_ld   => 'drugUnit',
 );
 
@@ -349,7 +349,7 @@ A food_warning should be one of the following types:
 
 has food_warning => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_food_warning',
     json_ld   => 'foodWarning',
 );
 
@@ -373,7 +373,7 @@ A included_in_health_insurance_plan should be one of the following types:
 
 has included_in_health_insurance_plan => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_included_in_health_insurance_plan',
     json_ld   => 'includedInHealthInsurancePlan',
 );
 
@@ -399,7 +399,7 @@ A interacting_drug should be one of the following types:
 
 has interacting_drug => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_interacting_drug',
     json_ld   => 'interactingDrug',
 );
 
@@ -423,7 +423,7 @@ A is_available_generically should be one of the following types:
 
 has is_available_generically => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_available_generically',
     json_ld   => 'isAvailableGenerically',
 );
 
@@ -447,7 +447,7 @@ A is_proprietary should be one of the following types:
 
 has is_proprietary => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_proprietary',
     json_ld   => 'isProprietary',
 );
 
@@ -471,7 +471,7 @@ A label_details should be one of the following types:
 
 has label_details => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_label_details',
     json_ld   => 'labelDetails',
 );
 
@@ -500,7 +500,7 @@ A legal_status should be one of the following types:
 
 has legal_status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legal_status',
     json_ld   => 'legalStatus',
 );
 
@@ -524,7 +524,7 @@ A manufacturer should be one of the following types:
 
 has manufacturer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_manufacturer',
     json_ld   => 'manufacturer',
 );
 
@@ -549,7 +549,7 @@ A maximum_intake should be one of the following types:
 
 has maximum_intake => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_maximum_intake',
     json_ld   => 'maximumIntake',
 );
 
@@ -574,7 +574,7 @@ A mechanism_of_action should be one of the following types:
 
 has mechanism_of_action => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_mechanism_of_action',
     json_ld   => 'mechanismOfAction',
 );
 
@@ -598,7 +598,7 @@ A non_proprietary_name should be one of the following types:
 
 has non_proprietary_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_non_proprietary_name',
     json_ld   => 'nonProprietaryName',
 );
 
@@ -623,7 +623,7 @@ A overdosage should be one of the following types:
 
 has overdosage => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_overdosage',
     json_ld   => 'overdosage',
 );
 
@@ -647,7 +647,7 @@ A pregnancy_category should be one of the following types:
 
 has pregnancy_category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pregnancy_category',
     json_ld   => 'pregnancyCategory',
 );
 
@@ -672,7 +672,7 @@ A pregnancy_warning should be one of the following types:
 
 has pregnancy_warning => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pregnancy_warning',
     json_ld   => 'pregnancyWarning',
 );
 
@@ -696,7 +696,7 @@ A prescribing_info should be one of the following types:
 
 has prescribing_info => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_prescribing_info',
     json_ld   => 'prescribingInfo',
 );
 
@@ -724,7 +724,7 @@ A prescription_status should be one of the following types:
 
 has prescription_status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_prescription_status',
     json_ld   => 'prescriptionStatus',
 );
 
@@ -749,7 +749,7 @@ A proprietary_name should be one of the following types:
 
 has proprietary_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_proprietary_name',
     json_ld   => 'proprietaryName',
 );
 
@@ -774,7 +774,7 @@ A related_drug should be one of the following types:
 
 has related_drug => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_related_drug',
     json_ld   => 'relatedDrug',
 );
 
@@ -798,7 +798,7 @@ A rxcui should be one of the following types:
 
 has rxcui => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_rxcui',
     json_ld   => 'rxcui',
 );
 
@@ -822,7 +822,7 @@ A warning should be one of the following types:
 
 has warning => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_warning',
     json_ld   => 'warning',
 );
 

--- a/lib/SemanticWeb/Schema/DrugClass.pm
+++ b/lib/SemanticWeb/Schema/DrugClass.pm
@@ -50,7 +50,7 @@ A drug should be one of the following types:
 
 has drug => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_drug',
     json_ld   => 'drug',
 );
 

--- a/lib/SemanticWeb/Schema/DrugCost.pm
+++ b/lib/SemanticWeb/Schema/DrugCost.pm
@@ -54,7 +54,7 @@ A applicable_location should be one of the following types:
 
 has applicable_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_applicable_location',
     json_ld   => 'applicableLocation',
 );
 
@@ -78,7 +78,7 @@ A cost_category should be one of the following types:
 
 has cost_category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cost_category',
     json_ld   => 'costCategory',
 );
 
@@ -103,7 +103,7 @@ A cost_currency should be one of the following types:
 
 has cost_currency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cost_currency',
     json_ld   => 'costCurrency',
 );
 
@@ -128,7 +128,7 @@ A cost_origin should be one of the following types:
 
 has cost_origin => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cost_origin',
     json_ld   => 'costOrigin',
 );
 
@@ -156,7 +156,7 @@ A cost_per_unit should be one of the following types:
 
 has cost_per_unit => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cost_per_unit',
     json_ld   => 'costPerUnit',
 );
 
@@ -180,7 +180,7 @@ A drug_unit should be one of the following types:
 
 has drug_unit => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_drug_unit',
     json_ld   => 'drugUnit',
 );
 

--- a/lib/SemanticWeb/Schema/DrugLegalStatus.pm
+++ b/lib/SemanticWeb/Schema/DrugLegalStatus.pm
@@ -48,7 +48,7 @@ A applicable_location should be one of the following types:
 
 has applicable_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_applicable_location',
     json_ld   => 'applicableLocation',
 );
 

--- a/lib/SemanticWeb/Schema/DrugStrength.pm
+++ b/lib/SemanticWeb/Schema/DrugStrength.pm
@@ -50,7 +50,7 @@ A active_ingredient should be one of the following types:
 
 has active_ingredient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_active_ingredient',
     json_ld   => 'activeIngredient',
 );
 
@@ -74,7 +74,7 @@ A available_in should be one of the following types:
 
 has available_in => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_in',
     json_ld   => 'availableIn',
 );
 
@@ -99,7 +99,7 @@ A maximum_intake should be one of the following types:
 
 has maximum_intake => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_maximum_intake',
     json_ld   => 'maximumIntake',
 );
 
@@ -123,7 +123,7 @@ A strength_unit should be one of the following types:
 
 has strength_unit => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_strength_unit',
     json_ld   => 'strengthUnit',
 );
 
@@ -147,7 +147,7 @@ A strength_value should be one of the following types:
 
 has strength_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_strength_value',
     json_ld   => 'strengthValue',
 );
 

--- a/lib/SemanticWeb/Schema/EducationalAudience.pm
+++ b/lib/SemanticWeb/Schema/EducationalAudience.pm
@@ -48,7 +48,7 @@ A educational_role should be one of the following types:
 
 has educational_role => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_educational_role',
     json_ld   => 'educationalRole',
 );
 

--- a/lib/SemanticWeb/Schema/EducationalOccupationalCredential.pm
+++ b/lib/SemanticWeb/Schema/EducationalOccupationalCredential.pm
@@ -53,7 +53,7 @@ A competency_required should be one of the following types:
 
 has competency_required => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_competency_required',
     json_ld   => 'competencyRequired',
 );
 
@@ -80,7 +80,7 @@ A credential_category should be one of the following types:
 
 has credential_category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_credential_category',
     json_ld   => 'credentialCategory',
 );
 
@@ -108,7 +108,7 @@ A educational_level should be one of the following types:
 
 has educational_level => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_educational_level',
     json_ld   => 'educationalLevel',
 );
 
@@ -134,7 +134,7 @@ A recognized_by should be one of the following types:
 
 has recognized_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recognized_by',
     json_ld   => 'recognizedBy',
 );
 
@@ -158,7 +158,7 @@ A valid_for should be one of the following types:
 
 has valid_for => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_for',
     json_ld   => 'validFor',
 );
 
@@ -182,7 +182,7 @@ A valid_in should be one of the following types:
 
 has valid_in => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_in',
     json_ld   => 'validIn',
 );
 

--- a/lib/SemanticWeb/Schema/EducationalOccupationalProgram.pm
+++ b/lib/SemanticWeb/Schema/EducationalOccupationalProgram.pm
@@ -57,7 +57,7 @@ A educational_credential_awarded should be one of the following types:
 
 has educational_credential_awarded => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_educational_credential_awarded',
     json_ld   => 'educationalCredentialAwarded',
 );
 
@@ -85,7 +85,7 @@ A occupational_credential_awarded should be one of the following types:
 
 has occupational_credential_awarded => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_occupational_credential_awarded',
     json_ld   => 'occupationalCredentialAwarded',
 );
 
@@ -111,7 +111,7 @@ A offers should be one of the following types:
 
 has offers => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_offers',
     json_ld   => 'offers',
 );
 
@@ -141,7 +141,7 @@ A program_prerequisites should be one of the following types:
 
 has program_prerequisites => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_program_prerequisites',
     json_ld   => 'programPrerequisites',
 );
 
@@ -169,7 +169,7 @@ A provider should be one of the following types:
 
 has provider => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_provider',
     json_ld   => 'provider',
 );
 
@@ -193,7 +193,7 @@ A salary_upon_completion should be one of the following types:
 
 has salary_upon_completion => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_salary_upon_completion',
     json_ld   => 'salaryUponCompletion',
 );
 
@@ -217,7 +217,7 @@ A time_to_complete should be one of the following types:
 
 has time_to_complete => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_time_to_complete',
     json_ld   => 'timeToComplete',
 );
 

--- a/lib/SemanticWeb/Schema/EducationalOrganization.pm
+++ b/lib/SemanticWeb/Schema/EducationalOrganization.pm
@@ -48,7 +48,7 @@ A alumni should be one of the following types:
 
 has alumni => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_alumni',
     json_ld   => 'alumni',
 );
 

--- a/lib/SemanticWeb/Schema/EmployeeRole.pm
+++ b/lib/SemanticWeb/Schema/EmployeeRole.pm
@@ -52,7 +52,7 @@ A base_salary should be one of the following types:
 
 has base_salary => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_base_salary',
     json_ld   => 'baseSalary',
 );
 
@@ -82,7 +82,7 @@ A salary_currency should be one of the following types:
 
 has salary_currency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_salary_currency',
     json_ld   => 'salaryCurrency',
 );
 

--- a/lib/SemanticWeb/Schema/EndorseAction.pm
+++ b/lib/SemanticWeb/Schema/EndorseAction.pm
@@ -50,7 +50,7 @@ A endorsee should be one of the following types:
 
 has endorsee => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_endorsee',
     json_ld   => 'endorsee',
 );
 

--- a/lib/SemanticWeb/Schema/EngineSpecification.pm
+++ b/lib/SemanticWeb/Schema/EngineSpecification.pm
@@ -61,7 +61,7 @@ A engine_displacement should be one of the following types:
 
 has engine_displacement => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_engine_displacement',
     json_ld   => 'engineDisplacement',
 );
 
@@ -101,7 +101,7 @@ A engine_power should be one of the following types:
 
 has engine_power => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_engine_power',
     json_ld   => 'enginePower',
 );
 
@@ -127,7 +127,7 @@ A engine_type should be one of the following types:
 
 has engine_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_engine_type',
     json_ld   => 'engineType',
 );
 
@@ -155,7 +155,7 @@ A fuel_type should be one of the following types:
 
 has fuel_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_fuel_type',
     json_ld   => 'fuelType',
 );
 
@@ -192,7 +192,7 @@ A torque should be one of the following types:
 
 has torque => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_torque',
     json_ld   => 'torque',
 );
 

--- a/lib/SemanticWeb/Schema/EntryPoint.pm
+++ b/lib/SemanticWeb/Schema/EntryPoint.pm
@@ -48,7 +48,7 @@ A action_application should be one of the following types:
 
 has action_application => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_action_application',
     json_ld   => 'actionApplication',
 );
 
@@ -74,7 +74,7 @@ A action_platform should be one of the following types:
 
 has action_platform => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_action_platform',
     json_ld   => 'actionPlatform',
 );
 
@@ -98,7 +98,7 @@ A application should be one of the following types:
 
 has application => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_application',
     json_ld   => 'application',
 );
 
@@ -122,7 +122,7 @@ A content_type should be one of the following types:
 
 has content_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_content_type',
     json_ld   => 'contentType',
 );
 
@@ -146,7 +146,7 @@ A encoding_type should be one of the following types:
 
 has encoding_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_encoding_type',
     json_ld   => 'encodingType',
 );
 
@@ -171,7 +171,7 @@ A http_method should be one of the following types:
 
 has http_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_http_method',
     json_ld   => 'httpMethod',
 );
 
@@ -196,7 +196,7 @@ A url_template should be one of the following types:
 
 has url_template => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_url_template',
     json_ld   => 'urlTemplate',
 );
 

--- a/lib/SemanticWeb/Schema/Enumeration.pm
+++ b/lib/SemanticWeb/Schema/Enumeration.pm
@@ -54,7 +54,7 @@ A superseded_by should be one of the following types:
 
 has superseded_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_superseded_by',
     json_ld   => 'supersededBy',
 );
 

--- a/lib/SemanticWeb/Schema/Episode.pm
+++ b/lib/SemanticWeb/Schema/Episode.pm
@@ -51,7 +51,7 @@ A actor should be one of the following types:
 
 has actor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actor',
     json_ld   => 'actor',
 );
 
@@ -76,7 +76,7 @@ A actors should be one of the following types:
 
 has actors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actors',
     json_ld   => 'actors',
 );
 
@@ -102,7 +102,7 @@ A director should be one of the following types:
 
 has director => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_director',
     json_ld   => 'director',
 );
 
@@ -127,7 +127,7 @@ A directors should be one of the following types:
 
 has directors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_directors',
     json_ld   => 'directors',
 );
 
@@ -153,7 +153,7 @@ A episode_number should be one of the following types:
 
 has episode_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_episode_number',
     json_ld   => 'episodeNumber',
 );
 
@@ -179,7 +179,7 @@ A music_by should be one of the following types:
 
 has music_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_music_by',
     json_ld   => 'musicBy',
 );
 
@@ -203,7 +203,7 @@ A part_of_season should be one of the following types:
 
 has part_of_season => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_part_of_season',
     json_ld   => 'partOfSeason',
 );
 
@@ -227,7 +227,7 @@ A part_of_series should be one of the following types:
 
 has part_of_series => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_part_of_series',
     json_ld   => 'partOfSeries',
 );
 
@@ -252,7 +252,7 @@ A production_company should be one of the following types:
 
 has production_company => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_production_company',
     json_ld   => 'productionCompany',
 );
 
@@ -276,7 +276,7 @@ A trailer should be one of the following types:
 
 has trailer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_trailer',
     json_ld   => 'trailer',
 );
 

--- a/lib/SemanticWeb/Schema/Event.pm
+++ b/lib/SemanticWeb/Schema/Event.pm
@@ -55,7 +55,7 @@ A about should be one of the following types:
 
 has about => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_about',
     json_ld   => 'about',
 );
 
@@ -81,7 +81,7 @@ A actor should be one of the following types:
 
 has actor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actor',
     json_ld   => 'actor',
 );
 
@@ -106,7 +106,7 @@ A aggregate_rating should be one of the following types:
 
 has aggregate_rating => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_aggregate_rating',
     json_ld   => 'aggregateRating',
 );
 
@@ -132,7 +132,7 @@ A attendee should be one of the following types:
 
 has attendee => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_attendee',
     json_ld   => 'attendee',
 );
 
@@ -158,7 +158,7 @@ A attendees should be one of the following types:
 
 has attendees => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_attendees',
     json_ld   => 'attendees',
 );
 
@@ -182,7 +182,7 @@ A audience should be one of the following types:
 
 has audience => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_audience',
     json_ld   => 'audience',
 );
 
@@ -209,7 +209,7 @@ A composer should be one of the following types:
 
 has composer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_composer',
     json_ld   => 'composer',
 );
 
@@ -235,7 +235,7 @@ A contributor should be one of the following types:
 
 has contributor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contributor',
     json_ld   => 'contributor',
 );
 
@@ -261,7 +261,7 @@ A director should be one of the following types:
 
 has director => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_director',
     json_ld   => 'director',
 );
 
@@ -285,7 +285,7 @@ A door_time should be one of the following types:
 
 has door_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_door_time',
     json_ld   => 'doorTime',
 );
 
@@ -314,7 +314,7 @@ A duration should be one of the following types:
 
 has duration => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_duration',
     json_ld   => 'duration',
 );
 
@@ -343,7 +343,7 @@ A end_date should be one of the following types:
 
 has end_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_end_date',
     json_ld   => 'endDate',
 );
 
@@ -368,7 +368,7 @@ A event_status should be one of the following types:
 
 has event_status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_event_status',
     json_ld   => 'eventStatus',
 );
 
@@ -395,7 +395,7 @@ A funder should be one of the following types:
 
 has funder => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_funder',
     json_ld   => 'funder',
 );
 
@@ -429,7 +429,7 @@ A in_language should be one of the following types:
 
 has in_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_in_language',
     json_ld   => 'inLanguage',
 );
 
@@ -453,7 +453,7 @@ A is_accessible_for_free should be one of the following types:
 
 has is_accessible_for_free => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_accessible_for_free',
     json_ld   => 'isAccessibleForFree',
 );
 
@@ -482,7 +482,7 @@ A location should be one of the following types:
 
 has location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_location',
     json_ld   => 'location',
 );
 
@@ -506,7 +506,7 @@ A maximum_attendee_capacity should be one of the following types:
 
 has maximum_attendee_capacity => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_maximum_attendee_capacity',
     json_ld   => 'maximumAttendeeCapacity',
 );
 
@@ -532,7 +532,7 @@ A offers should be one of the following types:
 
 has offers => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_offers',
     json_ld   => 'offers',
 );
 
@@ -558,7 +558,7 @@ A organizer should be one of the following types:
 
 has organizer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_organizer',
     json_ld   => 'organizer',
 );
 
@@ -585,7 +585,7 @@ A performer should be one of the following types:
 
 has performer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_performer',
     json_ld   => 'performer',
 );
 
@@ -612,7 +612,7 @@ A performers should be one of the following types:
 
 has performers => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_performers',
     json_ld   => 'performers',
 );
 
@@ -640,7 +640,7 @@ A previous_start_date should be one of the following types:
 
 has previous_start_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_previous_start_date',
     json_ld   => 'previousStartDate',
 );
 
@@ -664,7 +664,7 @@ A recorded_in should be one of the following types:
 
 has recorded_in => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recorded_in',
     json_ld   => 'recordedIn',
 );
 
@@ -688,7 +688,7 @@ A remaining_attendee_capacity should be one of the following types:
 
 has remaining_attendee_capacity => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_remaining_attendee_capacity',
     json_ld   => 'remainingAttendeeCapacity',
 );
 
@@ -712,7 +712,7 @@ A review should be one of the following types:
 
 has review => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_review',
     json_ld   => 'review',
 );
 
@@ -740,7 +740,7 @@ A sponsor should be one of the following types:
 
 has sponsor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sponsor',
     json_ld   => 'sponsor',
 );
 
@@ -769,7 +769,7 @@ A start_date should be one of the following types:
 
 has start_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_start_date',
     json_ld   => 'startDate',
 );
 
@@ -794,7 +794,7 @@ A sub_event should be one of the following types:
 
 has sub_event => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sub_event',
     json_ld   => 'subEvent',
 );
 
@@ -819,7 +819,7 @@ A sub_events should be one of the following types:
 
 has sub_events => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sub_events',
     json_ld   => 'subEvents',
 );
 
@@ -845,7 +845,7 @@ A super_event should be one of the following types:
 
 has super_event => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_super_event',
     json_ld   => 'superEvent',
 );
 
@@ -873,7 +873,7 @@ A translator should be one of the following types:
 
 has translator => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_translator',
     json_ld   => 'translator',
 );
 
@@ -897,7 +897,7 @@ A typical_age_range should be one of the following types:
 
 has typical_age_range => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_typical_age_range',
     json_ld   => 'typicalAgeRange',
 );
 
@@ -923,7 +923,7 @@ A work_featured should be one of the following types:
 
 has work_featured => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_work_featured',
     json_ld   => 'workFeatured',
 );
 
@@ -948,7 +948,7 @@ A work_performed should be one of the following types:
 
 has work_performed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_work_performed',
     json_ld   => 'workPerformed',
 );
 

--- a/lib/SemanticWeb/Schema/ExchangeRateSpecification.pm
+++ b/lib/SemanticWeb/Schema/ExchangeRateSpecification.pm
@@ -59,7 +59,7 @@ A currency should be one of the following types:
 
 has currency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_currency',
     json_ld   => 'currency',
 );
 
@@ -83,7 +83,7 @@ A current_exchange_rate should be one of the following types:
 
 has current_exchange_rate => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_current_exchange_rate',
     json_ld   => 'currentExchangeRate',
 );
 
@@ -110,7 +110,7 @@ A exchange_rate_spread should be one of the following types:
 
 has exchange_rate_spread => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_exchange_rate_spread',
     json_ld   => 'exchangeRateSpread',
 );
 

--- a/lib/SemanticWeb/Schema/ExerciseAction.pm
+++ b/lib/SemanticWeb/Schema/ExerciseAction.pm
@@ -49,7 +49,7 @@ A course should be one of the following types:
 
 has course => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_course',
     json_ld   => 'course',
 );
 
@@ -73,7 +73,7 @@ A diet should be one of the following types:
 
 has diet => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_diet',
     json_ld   => 'diet',
 );
 
@@ -97,7 +97,7 @@ A distance should be one of the following types:
 
 has distance => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_distance',
     json_ld   => 'distance',
 );
 
@@ -121,7 +121,7 @@ A exercise_course should be one of the following types:
 
 has exercise_course => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_exercise_course',
     json_ld   => 'exerciseCourse',
 );
 
@@ -145,7 +145,7 @@ A exercise_plan should be one of the following types:
 
 has exercise_plan => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_exercise_plan',
     json_ld   => 'exercisePlan',
 );
 
@@ -169,7 +169,7 @@ A exercise_related_diet should be one of the following types:
 
 has exercise_related_diet => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_exercise_related_diet',
     json_ld   => 'exerciseRelatedDiet',
 );
 
@@ -194,7 +194,7 @@ A exercise_type should be one of the following types:
 
 has exercise_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_exercise_type',
     json_ld   => 'exerciseType',
 );
 
@@ -219,7 +219,7 @@ A from_location should be one of the following types:
 
 has from_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_from_location',
     json_ld   => 'fromLocation',
 );
 
@@ -243,7 +243,7 @@ A opponent should be one of the following types:
 
 has opponent => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_opponent',
     json_ld   => 'opponent',
 );
 
@@ -268,7 +268,7 @@ A sports_activity_location should be one of the following types:
 
 has sports_activity_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sports_activity_location',
     json_ld   => 'sportsActivityLocation',
 );
 
@@ -292,7 +292,7 @@ A sports_event should be one of the following types:
 
 has sports_event => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sports_event',
     json_ld   => 'sportsEvent',
 );
 
@@ -317,7 +317,7 @@ A sports_team should be one of the following types:
 
 has sports_team => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sports_team',
     json_ld   => 'sportsTeam',
 );
 
@@ -342,7 +342,7 @@ A to_location should be one of the following types:
 
 has to_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_to_location',
     json_ld   => 'toLocation',
 );
 

--- a/lib/SemanticWeb/Schema/ExercisePlan.pm
+++ b/lib/SemanticWeb/Schema/ExercisePlan.pm
@@ -52,7 +52,7 @@ A activity_duration should be one of the following types:
 
 has activity_duration => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_activity_duration',
     json_ld   => 'activityDuration',
 );
 
@@ -78,7 +78,7 @@ A activity_frequency should be one of the following types:
 
 has activity_frequency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_activity_frequency',
     json_ld   => 'activityFrequency',
 );
 
@@ -105,7 +105,7 @@ A additional_variable should be one of the following types:
 
 has additional_variable => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_additional_variable',
     json_ld   => 'additionalVariable',
 );
 
@@ -130,7 +130,7 @@ A exercise_type should be one of the following types:
 
 has exercise_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_exercise_type',
     json_ld   => 'exerciseType',
 );
 
@@ -158,7 +158,7 @@ A intensity should be one of the following types:
 
 has intensity => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_intensity',
     json_ld   => 'intensity',
 );
 
@@ -184,7 +184,7 @@ A repetitions should be one of the following types:
 
 has repetitions => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_repetitions',
     json_ld   => 'repetitions',
 );
 
@@ -210,7 +210,7 @@ A rest_periods should be one of the following types:
 
 has rest_periods => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_rest_periods',
     json_ld   => 'restPeriods',
 );
 
@@ -237,7 +237,7 @@ A workload should be one of the following types:
 
 has workload => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_workload',
     json_ld   => 'workload',
 );
 

--- a/lib/SemanticWeb/Schema/FinancialProduct.pm
+++ b/lib/SemanticWeb/Schema/FinancialProduct.pm
@@ -56,7 +56,7 @@ A annual_percentage_rate should be one of the following types:
 
 has annual_percentage_rate => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_annual_percentage_rate',
     json_ld   => 'annualPercentageRate',
 );
 
@@ -81,7 +81,7 @@ A fees_and_commissions_specification should be one of the following types:
 
 has fees_and_commissions_specification => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_fees_and_commissions_specification',
     json_ld   => 'feesAndCommissionsSpecification',
 );
 
@@ -108,7 +108,7 @@ A interest_rate should be one of the following types:
 
 has interest_rate => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_interest_rate',
     json_ld   => 'interestRate',
 );
 

--- a/lib/SemanticWeb/Schema/FinancialService.pm
+++ b/lib/SemanticWeb/Schema/FinancialService.pm
@@ -49,7 +49,7 @@ A fees_and_commissions_specification should be one of the following types:
 
 has fees_and_commissions_specification => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_fees_and_commissions_specification',
     json_ld   => 'feesAndCommissionsSpecification',
 );
 

--- a/lib/SemanticWeb/Schema/Flight.pm
+++ b/lib/SemanticWeb/Schema/Flight.pm
@@ -50,7 +50,7 @@ A aircraft should be one of the following types:
 
 has aircraft => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_aircraft',
     json_ld   => 'aircraft',
 );
 
@@ -74,7 +74,7 @@ A arrival_airport should be one of the following types:
 
 has arrival_airport => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_arrival_airport',
     json_ld   => 'arrivalAirport',
 );
 
@@ -98,7 +98,7 @@ A arrival_gate should be one of the following types:
 
 has arrival_gate => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_arrival_gate',
     json_ld   => 'arrivalGate',
 );
 
@@ -122,7 +122,7 @@ A arrival_terminal should be one of the following types:
 
 has arrival_terminal => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_arrival_terminal',
     json_ld   => 'arrivalTerminal',
 );
 
@@ -147,7 +147,7 @@ A boarding_policy should be one of the following types:
 
 has boarding_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_boarding_policy',
     json_ld   => 'boardingPolicy',
 );
 
@@ -172,7 +172,7 @@ A carrier should be one of the following types:
 
 has carrier => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_carrier',
     json_ld   => 'carrier',
 );
 
@@ -196,7 +196,7 @@ A departure_airport should be one of the following types:
 
 has departure_airport => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_departure_airport',
     json_ld   => 'departureAirport',
 );
 
@@ -220,7 +220,7 @@ A departure_gate should be one of the following types:
 
 has departure_gate => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_departure_gate',
     json_ld   => 'departureGate',
 );
 
@@ -244,7 +244,7 @@ A departure_terminal should be one of the following types:
 
 has departure_terminal => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_departure_terminal',
     json_ld   => 'departureTerminal',
 );
 
@@ -270,7 +270,7 @@ A estimated_flight_duration should be one of the following types:
 
 has estimated_flight_duration => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_estimated_flight_duration',
     json_ld   => 'estimatedFlightDuration',
 );
 
@@ -296,7 +296,7 @@ A flight_distance should be one of the following types:
 
 has flight_distance => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_flight_distance',
     json_ld   => 'flightDistance',
 );
 
@@ -322,7 +322,7 @@ A flight_number should be one of the following types:
 
 has flight_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_flight_number',
     json_ld   => 'flightNumber',
 );
 
@@ -346,7 +346,7 @@ A meal_service should be one of the following types:
 
 has meal_service => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_meal_service',
     json_ld   => 'mealService',
 );
 
@@ -373,7 +373,7 @@ A seller should be one of the following types:
 
 has seller => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seller',
     json_ld   => 'seller',
 );
 
@@ -397,7 +397,7 @@ A web_checkin_time should be one of the following types:
 
 has web_checkin_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_web_checkin_time',
     json_ld   => 'webCheckinTime',
 );
 

--- a/lib/SemanticWeb/Schema/FlightReservation.pm
+++ b/lib/SemanticWeb/Schema/FlightReservation.pm
@@ -55,7 +55,7 @@ A boarding_group should be one of the following types:
 
 has boarding_group => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_boarding_group',
     json_ld   => 'boardingGroup',
 );
 
@@ -82,7 +82,7 @@ A passenger_priority_status should be one of the following types:
 
 has passenger_priority_status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_passenger_priority_status',
     json_ld   => 'passengerPriorityStatus',
 );
 
@@ -106,7 +106,7 @@ A passenger_sequence_number should be one of the following types:
 
 has passenger_sequence_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_passenger_sequence_number',
     json_ld   => 'passengerSequenceNumber',
 );
 
@@ -130,7 +130,7 @@ A security_screening should be one of the following types:
 
 has security_screening => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_security_screening',
     json_ld   => 'securityScreening',
 );
 

--- a/lib/SemanticWeb/Schema/FollowAction.pm
+++ b/lib/SemanticWeb/Schema/FollowAction.pm
@@ -73,7 +73,7 @@ A followee should be one of the following types:
 
 has followee => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_followee',
     json_ld   => 'followee',
 );
 

--- a/lib/SemanticWeb/Schema/FoodEstablishment.pm
+++ b/lib/SemanticWeb/Schema/FoodEstablishment.pm
@@ -56,7 +56,7 @@ A accepts_reservations should be one of the following types:
 
 has accepts_reservations => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_accepts_reservations',
     json_ld   => 'acceptsReservations',
 );
 
@@ -83,7 +83,7 @@ A has_menu should be one of the following types:
 
 has has_menu => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_menu',
     json_ld   => 'hasMenu',
 );
 
@@ -110,7 +110,7 @@ A menu should be one of the following types:
 
 has menu => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_menu',
     json_ld   => 'menu',
 );
 
@@ -134,7 +134,7 @@ A serves_cuisine should be one of the following types:
 
 has serves_cuisine => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_serves_cuisine',
     json_ld   => 'servesCuisine',
 );
 
@@ -161,7 +161,7 @@ A star_rating should be one of the following types:
 
 has star_rating => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_star_rating',
     json_ld   => 'starRating',
 );
 

--- a/lib/SemanticWeb/Schema/FoodEstablishmentReservation.pm
+++ b/lib/SemanticWeb/Schema/FoodEstablishmentReservation.pm
@@ -65,7 +65,7 @@ A end_time should be one of the following types:
 
 has end_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_end_time',
     json_ld   => 'endTime',
 );
 
@@ -91,7 +91,7 @@ A party_size should be one of the following types:
 
 has party_size => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_party_size',
     json_ld   => 'partySize',
 );
 
@@ -126,7 +126,7 @@ A start_time should be one of the following types:
 
 has start_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_start_time',
     json_ld   => 'startTime',
 );
 

--- a/lib/SemanticWeb/Schema/Game.pm
+++ b/lib/SemanticWeb/Schema/Game.pm
@@ -51,7 +51,7 @@ A character_attribute should be one of the following types:
 
 has character_attribute => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_character_attribute',
     json_ld   => 'characterAttribute',
 );
 
@@ -76,7 +76,7 @@ A game_item should be one of the following types:
 
 has game_item => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_game_item',
     json_ld   => 'gameItem',
 );
 
@@ -104,7 +104,7 @@ A game_location should be one of the following types:
 
 has game_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_game_location',
     json_ld   => 'gameLocation',
 );
 
@@ -128,7 +128,7 @@ A number_of_players should be one of the following types:
 
 has number_of_players => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_players',
     json_ld   => 'numberOfPlayers',
 );
 
@@ -153,7 +153,7 @@ A quest should be one of the following types:
 
 has quest => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_quest',
     json_ld   => 'quest',
 );
 

--- a/lib/SemanticWeb/Schema/GameServer.pm
+++ b/lib/SemanticWeb/Schema/GameServer.pm
@@ -48,7 +48,7 @@ A game should be one of the following types:
 
 has game => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_game',
     json_ld   => 'game',
 );
 
@@ -72,7 +72,7 @@ A players_online should be one of the following types:
 
 has players_online => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_players_online',
     json_ld   => 'playersOnline',
 );
 
@@ -96,7 +96,7 @@ A server_status should be one of the following types:
 
 has server_status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_server_status',
     json_ld   => 'serverStatus',
 );
 

--- a/lib/SemanticWeb/Schema/GeoCircle.pm
+++ b/lib/SemanticWeb/Schema/GeoCircle.pm
@@ -52,7 +52,7 @@ A geo_midpoint should be one of the following types:
 
 has geo_midpoint => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_midpoint',
     json_ld   => 'geoMidpoint',
 );
 
@@ -81,7 +81,7 @@ A geo_radius should be one of the following types:
 
 has geo_radius => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_radius',
     json_ld   => 'geoRadius',
 );
 

--- a/lib/SemanticWeb/Schema/GeoCoordinates.pm
+++ b/lib/SemanticWeb/Schema/GeoCoordinates.pm
@@ -50,7 +50,7 @@ A address should be one of the following types:
 
 has address => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_address',
     json_ld   => 'address',
 );
 
@@ -82,7 +82,7 @@ A address_country should be one of the following types:
 
 has address_country => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_address_country',
     json_ld   => 'addressCountry',
 );
 
@@ -116,7 +116,7 @@ A elevation should be one of the following types:
 
 has elevation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_elevation',
     json_ld   => 'elevation',
 );
 
@@ -147,7 +147,7 @@ A latitude should be one of the following types:
 
 has latitude => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_latitude',
     json_ld   => 'latitude',
 );
 
@@ -178,7 +178,7 @@ A longitude should be one of the following types:
 
 has longitude => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_longitude',
     json_ld   => 'longitude',
 );
 
@@ -202,7 +202,7 @@ A postal_code should be one of the following types:
 
 has postal_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_postal_code',
     json_ld   => 'postalCode',
 );
 

--- a/lib/SemanticWeb/Schema/GeoShape.pm
+++ b/lib/SemanticWeb/Schema/GeoShape.pm
@@ -53,7 +53,7 @@ A address should be one of the following types:
 
 has address => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_address',
     json_ld   => 'address',
 );
 
@@ -85,7 +85,7 @@ A address_country should be one of the following types:
 
 has address_country => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_address_country',
     json_ld   => 'addressCountry',
 );
 
@@ -111,7 +111,7 @@ A box should be one of the following types:
 
 has box => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_box',
     json_ld   => 'box',
 );
 
@@ -137,7 +137,7 @@ A circle should be one of the following types:
 
 has circle => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_circle',
     json_ld   => 'circle',
 );
 
@@ -171,7 +171,7 @@ A elevation should be one of the following types:
 
 has elevation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_elevation',
     json_ld   => 'elevation',
 );
 
@@ -196,7 +196,7 @@ A line should be one of the following types:
 
 has line => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_line',
     json_ld   => 'line',
 );
 
@@ -223,7 +223,7 @@ A polygon should be one of the following types:
 
 has polygon => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_polygon',
     json_ld   => 'polygon',
 );
 
@@ -247,7 +247,7 @@ A postal_code should be one of the following types:
 
 has postal_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_postal_code',
     json_ld   => 'postalCode',
 );
 

--- a/lib/SemanticWeb/Schema/GeospatialGeometry.pm
+++ b/lib/SemanticWeb/Schema/GeospatialGeometry.pm
@@ -59,7 +59,7 @@ A geo_contains should be one of the following types:
 
 has geo_contains => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_contains',
     json_ld   => 'geoContains',
 );
 
@@ -91,7 +91,7 @@ A geo_covered_by should be one of the following types:
 
 has geo_covered_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_covered_by',
     json_ld   => 'geoCoveredBy',
 );
 
@@ -124,7 +124,7 @@ A geo_covers should be one of the following types:
 
 has geo_covers => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_covers',
     json_ld   => 'geoCovers',
 );
 
@@ -158,7 +158,7 @@ A geo_crosses should be one of the following types:
 
 has geo_crosses => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_crosses',
     json_ld   => 'geoCrosses',
 );
 
@@ -191,7 +191,7 @@ A geo_disjoint should be one of the following types:
 
 has geo_disjoint => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_disjoint',
     json_ld   => 'geoDisjoint',
 );
 
@@ -226,7 +226,7 @@ A geo_equals should be one of the following types:
 
 has geo_equals => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_equals',
     json_ld   => 'geoEquals',
 );
 
@@ -258,7 +258,7 @@ A geo_intersects should be one of the following types:
 
 has geo_intersects => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_intersects',
     json_ld   => 'geoIntersects',
 );
 
@@ -291,7 +291,7 @@ A geo_overlaps should be one of the following types:
 
 has geo_overlaps => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_overlaps',
     json_ld   => 'geoOverlaps',
 );
 
@@ -324,7 +324,7 @@ A geo_touches should be one of the following types:
 
 has geo_touches => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_touches',
     json_ld   => 'geoTouches',
 );
 
@@ -357,7 +357,7 @@ A geo_within should be one of the following types:
 
 has geo_within => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_within',
     json_ld   => 'geoWithin',
 );
 

--- a/lib/SemanticWeb/Schema/GiveAction.pm
+++ b/lib/SemanticWeb/Schema/GiveAction.pm
@@ -65,7 +65,7 @@ A recipient should be one of the following types:
 
 has recipient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipient',
     json_ld   => 'recipient',
 );
 

--- a/lib/SemanticWeb/Schema/GovernmentService.pm
+++ b/lib/SemanticWeb/Schema/GovernmentService.pm
@@ -51,7 +51,7 @@ A service_operator should be one of the following types:
 
 has service_operator => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_service_operator',
     json_ld   => 'serviceOperator',
 );
 

--- a/lib/SemanticWeb/Schema/Grant.pm
+++ b/lib/SemanticWeb/Schema/Grant.pm
@@ -81,7 +81,7 @@ A funded_item should be one of the following types:
 
 has funded_item => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_funded_item',
     json_ld   => 'fundedItem',
 );
 
@@ -109,7 +109,7 @@ A sponsor should be one of the following types:
 
 has sponsor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sponsor',
     json_ld   => 'sponsor',
 );
 

--- a/lib/SemanticWeb/Schema/HealthInsurancePlan.pm
+++ b/lib/SemanticWeb/Schema/HealthInsurancePlan.pm
@@ -49,7 +49,7 @@ A benefits_summary_url should be one of the following types:
 
 has benefits_summary_url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_benefits_summary_url',
     json_ld   => 'benefitsSummaryUrl',
 );
 
@@ -73,7 +73,7 @@ A contact_point should be one of the following types:
 
 has contact_point => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contact_point',
     json_ld   => 'contactPoint',
 );
 
@@ -97,7 +97,7 @@ A health_plan_drug_option should be one of the following types:
 
 has health_plan_drug_option => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_drug_option',
     json_ld   => 'healthPlanDrugOption',
 );
 
@@ -121,7 +121,7 @@ A health_plan_drug_tier should be one of the following types:
 
 has health_plan_drug_tier => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_drug_tier',
     json_ld   => 'healthPlanDrugTier',
 );
 
@@ -146,7 +146,7 @@ A health_plan_id should be one of the following types:
 
 has health_plan_id => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_id',
     json_ld   => 'healthPlanId',
 );
 
@@ -171,7 +171,7 @@ A health_plan_marketing_url should be one of the following types:
 
 has health_plan_marketing_url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_marketing_url',
     json_ld   => 'healthPlanMarketingUrl',
 );
 
@@ -195,7 +195,7 @@ A includes_health_plan_formulary should be one of the following types:
 
 has includes_health_plan_formulary => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_includes_health_plan_formulary',
     json_ld   => 'includesHealthPlanFormulary',
 );
 
@@ -219,7 +219,7 @@ A includes_health_plan_network should be one of the following types:
 
 has includes_health_plan_network => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_includes_health_plan_network',
     json_ld   => 'includesHealthPlanNetwork',
 );
 
@@ -244,7 +244,7 @@ A uses_health_plan_id_standard should be one of the following types:
 
 has uses_health_plan_id_standard => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_uses_health_plan_id_standard',
     json_ld   => 'usesHealthPlanIdStandard',
 );
 

--- a/lib/SemanticWeb/Schema/HealthPlanCostSharingSpecification.pm
+++ b/lib/SemanticWeb/Schema/HealthPlanCostSharingSpecification.pm
@@ -49,7 +49,7 @@ A health_plan_coinsurance_option should be one of the following types:
 
 has health_plan_coinsurance_option => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_coinsurance_option',
     json_ld   => 'healthPlanCoinsuranceOption',
 );
 
@@ -73,7 +73,7 @@ A health_plan_coinsurance_rate should be one of the following types:
 
 has health_plan_coinsurance_rate => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_coinsurance_rate',
     json_ld   => 'healthPlanCoinsuranceRate',
 );
 
@@ -97,7 +97,7 @@ A health_plan_copay should be one of the following types:
 
 has health_plan_copay => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_copay',
     json_ld   => 'healthPlanCopay',
 );
 
@@ -122,7 +122,7 @@ A health_plan_copay_option should be one of the following types:
 
 has health_plan_copay_option => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_copay_option',
     json_ld   => 'healthPlanCopayOption',
 );
 
@@ -146,7 +146,7 @@ A health_plan_pharmacy_category should be one of the following types:
 
 has health_plan_pharmacy_category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_pharmacy_category',
     json_ld   => 'healthPlanPharmacyCategory',
 );
 

--- a/lib/SemanticWeb/Schema/HealthPlanFormulary.pm
+++ b/lib/SemanticWeb/Schema/HealthPlanFormulary.pm
@@ -50,7 +50,7 @@ A health_plan_cost_sharing should be one of the following types:
 
 has health_plan_cost_sharing => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_cost_sharing',
     json_ld   => 'healthPlanCostSharing',
 );
 
@@ -74,7 +74,7 @@ A health_plan_drug_tier should be one of the following types:
 
 has health_plan_drug_tier => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_drug_tier',
     json_ld   => 'healthPlanDrugTier',
 );
 
@@ -98,7 +98,7 @@ A offers_prescription_by_mail should be one of the following types:
 
 has offers_prescription_by_mail => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_offers_prescription_by_mail',
     json_ld   => 'offersPrescriptionByMail',
 );
 

--- a/lib/SemanticWeb/Schema/HealthPlanNetwork.pm
+++ b/lib/SemanticWeb/Schema/HealthPlanNetwork.pm
@@ -49,7 +49,7 @@ A health_plan_cost_sharing should be one of the following types:
 
 has health_plan_cost_sharing => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_cost_sharing',
     json_ld   => 'healthPlanCostSharing',
 );
 
@@ -74,7 +74,7 @@ A health_plan_network_id should be one of the following types:
 
 has health_plan_network_id => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_network_id',
     json_ld   => 'healthPlanNetworkId',
 );
 
@@ -98,7 +98,7 @@ A health_plan_network_tier should be one of the following types:
 
 has health_plan_network_tier => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_network_tier',
     json_ld   => 'healthPlanNetworkTier',
 );
 

--- a/lib/SemanticWeb/Schema/HealthTopicContent.pm
+++ b/lib/SemanticWeb/Schema/HealthTopicContent.pm
@@ -77,7 +77,7 @@ A has_health_aspect should be one of the following types:
 
 has has_health_aspect => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_health_aspect',
     json_ld   => 'hasHealthAspect',
 );
 

--- a/lib/SemanticWeb/Schema/Hospital.pm
+++ b/lib/SemanticWeb/Schema/Hospital.pm
@@ -52,7 +52,7 @@ A available_service should be one of the following types:
 
 has available_service => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_service',
     json_ld   => 'availableService',
 );
 
@@ -76,7 +76,7 @@ A medical_specialty should be one of the following types:
 
 has medical_specialty => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_medical_specialty',
     json_ld   => 'medicalSpecialty',
 );
 

--- a/lib/SemanticWeb/Schema/HotelRoom.pm
+++ b/lib/SemanticWeb/Schema/HotelRoom.pm
@@ -61,7 +61,7 @@ A bed should be one of the following types:
 
 has bed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_bed',
     json_ld   => 'bed',
 );
 
@@ -89,7 +89,7 @@ A occupancy should be one of the following types:
 
 has occupancy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_occupancy',
     json_ld   => 'occupancy',
 );
 

--- a/lib/SemanticWeb/Schema/House.pm
+++ b/lib/SemanticWeb/Schema/House.pm
@@ -61,7 +61,7 @@ A number_of_rooms should be one of the following types:
 
 has number_of_rooms => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_rooms',
     json_ld   => 'numberOfRooms',
 );
 

--- a/lib/SemanticWeb/Schema/HowTo.pm
+++ b/lib/SemanticWeb/Schema/HowTo.pm
@@ -52,7 +52,7 @@ A estimated_cost should be one of the following types:
 
 has estimated_cost => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_estimated_cost',
     json_ld   => 'estimatedCost',
 );
 
@@ -83,7 +83,7 @@ A perform_time should be one of the following types:
 
 has perform_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_perform_time',
     json_ld   => 'performTime',
 );
 
@@ -114,7 +114,7 @@ A prep_time should be one of the following types:
 
 has prep_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_prep_time',
     json_ld   => 'prepTime',
 );
 
@@ -145,7 +145,7 @@ A step should be one of the following types:
 
 has step => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_step',
     json_ld   => 'step',
 );
 
@@ -174,7 +174,7 @@ A steps should be one of the following types:
 
 has steps => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_steps',
     json_ld   => 'steps',
 );
 
@@ -201,7 +201,7 @@ A supply should be one of the following types:
 
 has supply => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_supply',
     json_ld   => 'supply',
 );
 
@@ -228,7 +228,7 @@ A tool should be one of the following types:
 
 has tool => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_tool',
     json_ld   => 'tool',
 );
 
@@ -259,7 +259,7 @@ A total_time should be one of the following types:
 
 has total_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_total_time',
     json_ld   => 'totalTime',
 );
 
@@ -286,7 +286,7 @@ A yield should be one of the following types:
 
 has yield => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_yield',
     json_ld   => 'yield',
 );
 

--- a/lib/SemanticWeb/Schema/HowToDirection.pm
+++ b/lib/SemanticWeb/Schema/HowToDirection.pm
@@ -52,7 +52,7 @@ A after_media should be one of the following types:
 
 has after_media => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_after_media',
     json_ld   => 'afterMedia',
 );
 
@@ -79,7 +79,7 @@ A before_media should be one of the following types:
 
 has before_media => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_before_media',
     json_ld   => 'beforeMedia',
 );
 
@@ -106,7 +106,7 @@ A during_media should be one of the following types:
 
 has during_media => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_during_media',
     json_ld   => 'duringMedia',
 );
 
@@ -137,7 +137,7 @@ A perform_time should be one of the following types:
 
 has perform_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_perform_time',
     json_ld   => 'performTime',
 );
 
@@ -168,7 +168,7 @@ A prep_time should be one of the following types:
 
 has prep_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_prep_time',
     json_ld   => 'prepTime',
 );
 
@@ -195,7 +195,7 @@ A supply should be one of the following types:
 
 has supply => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_supply',
     json_ld   => 'supply',
 );
 
@@ -222,7 +222,7 @@ A tool should be one of the following types:
 
 has tool => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_tool',
     json_ld   => 'tool',
 );
 
@@ -253,7 +253,7 @@ A total_time should be one of the following types:
 
 has total_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_total_time',
     json_ld   => 'totalTime',
 );
 

--- a/lib/SemanticWeb/Schema/HowToItem.pm
+++ b/lib/SemanticWeb/Schema/HowToItem.pm
@@ -53,7 +53,7 @@ A required_quantity should be one of the following types:
 
 has required_quantity => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_required_quantity',
     json_ld   => 'requiredQuantity',
 );
 

--- a/lib/SemanticWeb/Schema/HowToSection.pm
+++ b/lib/SemanticWeb/Schema/HowToSection.pm
@@ -54,7 +54,7 @@ A steps should be one of the following types:
 
 has steps => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_steps',
     json_ld   => 'steps',
 );
 

--- a/lib/SemanticWeb/Schema/HowToSupply.pm
+++ b/lib/SemanticWeb/Schema/HowToSupply.pm
@@ -52,7 +52,7 @@ A estimated_cost should be one of the following types:
 
 has estimated_cost => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_estimated_cost',
     json_ld   => 'estimatedCost',
 );
 

--- a/lib/SemanticWeb/Schema/ImageObject.pm
+++ b/lib/SemanticWeb/Schema/ImageObject.pm
@@ -57,7 +57,7 @@ A caption should be one of the following types:
 
 has caption => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_caption',
     json_ld   => 'caption',
 );
 
@@ -83,7 +83,7 @@ A exif_data should be one of the following types:
 
 has exif_data => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_exif_data',
     json_ld   => 'exifData',
 );
 
@@ -107,7 +107,7 @@ A representative_of_page should be one of the following types:
 
 has representative_of_page => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_representative_of_page',
     json_ld   => 'representativeOfPage',
 );
 
@@ -131,7 +131,7 @@ A thumbnail should be one of the following types:
 
 has thumbnail => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_thumbnail',
     json_ld   => 'thumbnail',
 );
 

--- a/lib/SemanticWeb/Schema/ImagingTest.pm
+++ b/lib/SemanticWeb/Schema/ImagingTest.pm
@@ -48,7 +48,7 @@ A imaging_technique should be one of the following types:
 
 has imaging_technique => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_imaging_technique',
     json_ld   => 'imagingTechnique',
 );
 

--- a/lib/SemanticWeb/Schema/IndividualProduct.pm
+++ b/lib/SemanticWeb/Schema/IndividualProduct.pm
@@ -51,7 +51,7 @@ A serial_number should be one of the following types:
 
 has serial_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_serial_number',
     json_ld   => 'serialNumber',
 );
 

--- a/lib/SemanticWeb/Schema/InfectiousDisease.pm
+++ b/lib/SemanticWeb/Schema/InfectiousDisease.pm
@@ -52,7 +52,7 @@ A infectious_agent should be one of the following types:
 
 has infectious_agent => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_infectious_agent',
     json_ld   => 'infectiousAgent',
 );
 
@@ -77,7 +77,7 @@ A infectious_agent_class should be one of the following types:
 
 has infectious_agent_class => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_infectious_agent_class',
     json_ld   => 'infectiousAgentClass',
 );
 
@@ -102,7 +102,7 @@ A transmission_method should be one of the following types:
 
 has transmission_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_transmission_method',
     json_ld   => 'transmissionMethod',
 );
 

--- a/lib/SemanticWeb/Schema/InformAction.pm
+++ b/lib/SemanticWeb/Schema/InformAction.pm
@@ -49,7 +49,7 @@ A event should be one of the following types:
 
 has event => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_event',
     json_ld   => 'event',
 );
 

--- a/lib/SemanticWeb/Schema/InsertAction.pm
+++ b/lib/SemanticWeb/Schema/InsertAction.pm
@@ -49,7 +49,7 @@ A to_location should be one of the following types:
 
 has to_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_to_location',
     json_ld   => 'toLocation',
 );
 

--- a/lib/SemanticWeb/Schema/InteractionCounter.pm
+++ b/lib/SemanticWeb/Schema/InteractionCounter.pm
@@ -52,7 +52,7 @@ A interaction_service should be one of the following types:
 
 has interaction_service => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_interaction_service',
     json_ld   => 'interactionService',
 );
 
@@ -84,7 +84,7 @@ A interaction_type should be one of the following types:
 
 has interaction_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_interaction_type',
     json_ld   => 'interactionType',
 );
 
@@ -109,7 +109,7 @@ A user_interaction_count should be one of the following types:
 
 has user_interaction_count => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_user_interaction_count',
     json_ld   => 'userInteractionCount',
 );
 

--- a/lib/SemanticWeb/Schema/InvestmentOrDeposit.pm
+++ b/lib/SemanticWeb/Schema/InvestmentOrDeposit.pm
@@ -52,7 +52,7 @@ A amount should be one of the following types:
 
 has amount => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_amount',
     json_ld   => 'amount',
 );
 

--- a/lib/SemanticWeb/Schema/InviteAction.pm
+++ b/lib/SemanticWeb/Schema/InviteAction.pm
@@ -48,7 +48,7 @@ A event should be one of the following types:
 
 has event => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_event',
     json_ld   => 'event',
 );
 

--- a/lib/SemanticWeb/Schema/Invoice.pm
+++ b/lib/SemanticWeb/Schema/Invoice.pm
@@ -48,7 +48,7 @@ A account_id should be one of the following types:
 
 has account_id => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_account_id',
     json_ld   => 'accountId',
 );
 
@@ -72,7 +72,7 @@ A billing_period should be one of the following types:
 
 has billing_period => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_billing_period',
     json_ld   => 'billingPeriod',
 );
 
@@ -101,7 +101,7 @@ A broker should be one of the following types:
 
 has broker => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broker',
     json_ld   => 'broker',
 );
 
@@ -130,7 +130,7 @@ A category should be one of the following types:
 
 has category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_category',
     json_ld   => 'category',
 );
 
@@ -154,7 +154,7 @@ A confirmation_number should be one of the following types:
 
 has confirmation_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_confirmation_number',
     json_ld   => 'confirmationNumber',
 );
 
@@ -180,7 +180,7 @@ A customer should be one of the following types:
 
 has customer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_customer',
     json_ld   => 'customer',
 );
 
@@ -206,7 +206,7 @@ A minimum_payment_due should be one of the following types:
 
 has minimum_payment_due => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_minimum_payment_due',
     json_ld   => 'minimumPaymentDue',
 );
 
@@ -230,7 +230,7 @@ A payment_due should be one of the following types:
 
 has payment_due => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_payment_due',
     json_ld   => 'paymentDue',
 );
 
@@ -254,7 +254,7 @@ A payment_due_date should be one of the following types:
 
 has payment_due_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_payment_due_date',
     json_ld   => 'paymentDueDate',
 );
 
@@ -278,7 +278,7 @@ A payment_method should be one of the following types:
 
 has payment_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_payment_method',
     json_ld   => 'paymentMethod',
 );
 
@@ -303,7 +303,7 @@ A payment_method_id should be one of the following types:
 
 has payment_method_id => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_payment_method_id',
     json_ld   => 'paymentMethodId',
 );
 
@@ -329,7 +329,7 @@ A payment_status should be one of the following types:
 
 has payment_status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_payment_status',
     json_ld   => 'paymentStatus',
 );
 
@@ -357,7 +357,7 @@ A provider should be one of the following types:
 
 has provider => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_provider',
     json_ld   => 'provider',
 );
 
@@ -382,7 +382,7 @@ A references_order should be one of the following types:
 
 has references_order => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_references_order',
     json_ld   => 'referencesOrder',
 );
 
@@ -406,7 +406,7 @@ A scheduled_payment_date should be one of the following types:
 
 has scheduled_payment_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_scheduled_payment_date',
     json_ld   => 'scheduledPaymentDate',
 );
 
@@ -432,7 +432,7 @@ A total_payment_due should be one of the following types:
 
 has total_payment_due => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_total_payment_due',
     json_ld   => 'totalPaymentDue',
 );
 

--- a/lib/SemanticWeb/Schema/ItemList.pm
+++ b/lib/SemanticWeb/Schema/ItemList.pm
@@ -66,7 +66,7 @@ A item_list_element should be one of the following types:
 
 has item_list_element => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_item_list_element',
     json_ld   => 'itemListElement',
 );
 
@@ -92,7 +92,7 @@ A item_list_order should be one of the following types:
 
 has item_list_order => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_item_list_order',
     json_ld   => 'itemListOrder',
 );
 
@@ -118,7 +118,7 @@ A number_of_items should be one of the following types:
 
 has number_of_items => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_items',
     json_ld   => 'numberOfItems',
 );
 

--- a/lib/SemanticWeb/Schema/JobPosting.pm
+++ b/lib/SemanticWeb/Schema/JobPosting.pm
@@ -51,7 +51,7 @@ A applicant_location_requirements should be one of the following types:
 
 has applicant_location_requirements => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_applicant_location_requirements',
     json_ld   => 'applicantLocationRequirements',
 );
 
@@ -79,7 +79,7 @@ A base_salary should be one of the following types:
 
 has base_salary => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_base_salary',
     json_ld   => 'baseSalary',
 );
 
@@ -103,7 +103,7 @@ A benefits should be one of the following types:
 
 has benefits => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_benefits',
     json_ld   => 'benefits',
 );
 
@@ -127,7 +127,7 @@ A date_posted should be one of the following types:
 
 has date_posted => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_date_posted',
     json_ld   => 'datePosted',
 );
 
@@ -153,7 +153,7 @@ A education_requirements should be one of the following types:
 
 has education_requirements => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_education_requirements',
     json_ld   => 'educationRequirements',
 );
 
@@ -178,7 +178,7 @@ A employment_type should be one of the following types:
 
 has employment_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_employment_type',
     json_ld   => 'employmentType',
 );
 
@@ -203,7 +203,7 @@ A employment_unit should be one of the following types:
 
 has employment_unit => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_employment_unit',
     json_ld   => 'employmentUnit',
 );
 
@@ -234,7 +234,7 @@ A estimated_salary should be one of the following types:
 
 has estimated_salary => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_estimated_salary',
     json_ld   => 'estimatedSalary',
 );
 
@@ -258,7 +258,7 @@ A experience_requirements should be one of the following types:
 
 has experience_requirements => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_experience_requirements',
     json_ld   => 'experienceRequirements',
 );
 
@@ -282,7 +282,7 @@ A hiring_organization should be one of the following types:
 
 has hiring_organization => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_hiring_organization',
     json_ld   => 'hiringOrganization',
 );
 
@@ -306,7 +306,7 @@ A incentive_compensation should be one of the following types:
 
 has incentive_compensation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_incentive_compensation',
     json_ld   => 'incentiveCompensation',
 );
 
@@ -330,7 +330,7 @@ A incentives should be one of the following types:
 
 has incentives => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_incentives',
     json_ld   => 'incentives',
 );
 
@@ -354,7 +354,7 @@ A industry should be one of the following types:
 
 has industry => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_industry',
     json_ld   => 'industry',
 );
 
@@ -378,7 +378,7 @@ A job_benefits should be one of the following types:
 
 has job_benefits => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_job_benefits',
     json_ld   => 'jobBenefits',
 );
 
@@ -402,7 +402,7 @@ A job_immediate_start should be one of the following types:
 
 has job_immediate_start => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_job_immediate_start',
     json_ld   => 'jobImmediateStart',
 );
 
@@ -426,7 +426,7 @@ A job_location should be one of the following types:
 
 has job_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_job_location',
     json_ld   => 'jobLocation',
 );
 
@@ -450,7 +450,7 @@ A job_location_type should be one of the following types:
 
 has job_location_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_job_location_type',
     json_ld   => 'jobLocationType',
 );
 
@@ -477,7 +477,7 @@ A job_start_date should be one of the following types:
 
 has job_start_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_job_start_date',
     json_ld   => 'jobStartDate',
 );
 
@@ -515,7 +515,7 @@ A occupational_category should be one of the following types:
 
 has occupational_category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_occupational_category',
     json_ld   => 'occupationalCategory',
 );
 
@@ -541,7 +541,7 @@ A qualifications should be one of the following types:
 
 has qualifications => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_qualifications',
     json_ld   => 'qualifications',
 );
 
@@ -565,7 +565,7 @@ A relevant_occupation should be one of the following types:
 
 has relevant_occupation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_relevant_occupation',
     json_ld   => 'relevantOccupation',
 );
 
@@ -589,7 +589,7 @@ A responsibilities should be one of the following types:
 
 has responsibilities => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_responsibilities',
     json_ld   => 'responsibilities',
 );
 
@@ -619,7 +619,7 @@ A salary_currency should be one of the following types:
 
 has salary_currency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_salary_currency',
     json_ld   => 'salaryCurrency',
 );
 
@@ -647,7 +647,7 @@ A skills should be one of the following types:
 
 has skills => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_skills',
     json_ld   => 'skills',
 );
 
@@ -672,7 +672,7 @@ A special_commitments should be one of the following types:
 
 has special_commitments => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_special_commitments',
     json_ld   => 'specialCommitments',
 );
 
@@ -696,7 +696,7 @@ A title should be one of the following types:
 
 has title => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_title',
     json_ld   => 'title',
 );
 
@@ -721,7 +721,7 @@ A total_job_openings should be one of the following types:
 
 has total_job_openings => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_total_job_openings',
     json_ld   => 'totalJobOpenings',
 );
 
@@ -746,7 +746,7 @@ A valid_through should be one of the following types:
 
 has valid_through => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_through',
     json_ld   => 'validThrough',
 );
 
@@ -771,7 +771,7 @@ A work_hours should be one of the following types:
 
 has work_hours => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_work_hours',
     json_ld   => 'workHours',
 );
 

--- a/lib/SemanticWeb/Schema/JoinAction.pm
+++ b/lib/SemanticWeb/Schema/JoinAction.pm
@@ -63,7 +63,7 @@ A event should be one of the following types:
 
 has event => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_event',
     json_ld   => 'event',
 );
 

--- a/lib/SemanticWeb/Schema/Joint.pm
+++ b/lib/SemanticWeb/Schema/Joint.pm
@@ -48,7 +48,7 @@ A biomechnical_class should be one of the following types:
 
 has biomechnical_class => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_biomechnical_class',
     json_ld   => 'biomechnicalClass',
 );
 
@@ -74,7 +74,7 @@ A functional_class should be one of the following types:
 
 has functional_class => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_functional_class',
     json_ld   => 'functionalClass',
 );
 
@@ -98,7 +98,7 @@ A structural_class should be one of the following types:
 
 has structural_class => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_structural_class',
     json_ld   => 'structuralClass',
 );
 

--- a/lib/SemanticWeb/Schema/LeaveAction.pm
+++ b/lib/SemanticWeb/Schema/LeaveAction.pm
@@ -58,7 +58,7 @@ A event should be one of the following types:
 
 has event => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_event',
     json_ld   => 'event',
 );
 

--- a/lib/SemanticWeb/Schema/Legislation.pm
+++ b/lib/SemanticWeb/Schema/Legislation.pm
@@ -60,7 +60,7 @@ A legislation_applies should be one of the following types:
 
 has legislation_applies => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legislation_applies',
     json_ld   => 'legislationApplies',
 );
 
@@ -95,7 +95,7 @@ A legislation_changes should be one of the following types:
 
 has legislation_changes => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legislation_changes',
     json_ld   => 'legislationChanges',
 );
 
@@ -123,7 +123,7 @@ A legislation_consolidates should be one of the following types:
 
 has legislation_consolidates => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legislation_consolidates',
     json_ld   => 'legislationConsolidates',
 );
 
@@ -149,7 +149,7 @@ A legislation_date should be one of the following types:
 
 has legislation_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legislation_date',
     json_ld   => 'legislationDate',
 );
 
@@ -176,7 +176,7 @@ A legislation_date_version should be one of the following types:
 
 has legislation_date_version => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legislation_date_version',
     json_ld   => 'legislationDateVersion',
 );
 
@@ -203,7 +203,7 @@ A legislation_identifier should be one of the following types:
 
 has legislation_identifier => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legislation_identifier',
     json_ld   => 'legislationIdentifier',
 );
 
@@ -229,7 +229,7 @@ A legislation_jurisdiction should be one of the following types:
 
 has legislation_jurisdiction => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legislation_jurisdiction',
     json_ld   => 'legislationJurisdiction',
 );
 
@@ -254,7 +254,7 @@ A legislation_legal_force should be one of the following types:
 
 has legislation_legal_force => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legislation_legal_force',
     json_ld   => 'legislationLegalForce',
 );
 
@@ -283,7 +283,7 @@ A legislation_passed_by should be one of the following types:
 
 has legislation_passed_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legislation_passed_by',
     json_ld   => 'legislationPassedBy',
 );
 
@@ -312,7 +312,7 @@ A legislation_responsible should be one of the following types:
 
 has legislation_responsible => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legislation_responsible',
     json_ld   => 'legislationResponsible',
 );
 
@@ -340,7 +340,7 @@ A legislation_transposes should be one of the following types:
 
 has legislation_transposes => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legislation_transposes',
     json_ld   => 'legislationTransposes',
 );
 
@@ -368,7 +368,7 @@ A legislation_type should be one of the following types:
 
 has legislation_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legislation_type',
     json_ld   => 'legislationType',
 );
 

--- a/lib/SemanticWeb/Schema/LegislationObject.pm
+++ b/lib/SemanticWeb/Schema/LegislationObject.pm
@@ -53,7 +53,7 @@ A legislation_legal_value should be one of the following types:
 
 has legislation_legal_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legislation_legal_value',
     json_ld   => 'legislationLegalValue',
 );
 

--- a/lib/SemanticWeb/Schema/LendAction.pm
+++ b/lib/SemanticWeb/Schema/LendAction.pm
@@ -57,7 +57,7 @@ A borrower should be one of the following types:
 
 has borrower => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_borrower',
     json_ld   => 'borrower',
 );
 

--- a/lib/SemanticWeb/Schema/LinkRole.pm
+++ b/lib/SemanticWeb/Schema/LinkRole.pm
@@ -62,7 +62,7 @@ A in_language should be one of the following types:
 
 has in_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_in_language',
     json_ld   => 'inLanguage',
 );
 
@@ -86,7 +86,7 @@ A link_relationship should be one of the following types:
 
 has link_relationship => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_link_relationship',
     json_ld   => 'linkRelationship',
 );
 

--- a/lib/SemanticWeb/Schema/ListItem.pm
+++ b/lib/SemanticWeb/Schema/ListItem.pm
@@ -49,7 +49,7 @@ A item should be one of the following types:
 
 has item => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_item',
     json_ld   => 'item',
 );
 
@@ -73,7 +73,7 @@ A next_item should be one of the following types:
 
 has next_item => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_next_item',
     json_ld   => 'nextItem',
 );
 
@@ -99,7 +99,7 @@ A position should be one of the following types:
 
 has position => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_position',
     json_ld   => 'position',
 );
 
@@ -123,7 +123,7 @@ A previous_item should be one of the following types:
 
 has previous_item => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_previous_item',
     json_ld   => 'previousItem',
 );
 

--- a/lib/SemanticWeb/Schema/LiveBlogPosting.pm
+++ b/lib/SemanticWeb/Schema/LiveBlogPosting.pm
@@ -50,7 +50,7 @@ A coverage_end_time should be one of the following types:
 
 has coverage_end_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_coverage_end_time',
     json_ld   => 'coverageEndTime',
 );
 
@@ -76,7 +76,7 @@ A coverage_start_time should be one of the following types:
 
 has coverage_start_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_coverage_start_time',
     json_ld   => 'coverageStartTime',
 );
 
@@ -100,7 +100,7 @@ A live_blog_update should be one of the following types:
 
 has live_blog_update => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_live_blog_update',
     json_ld   => 'liveBlogUpdate',
 );
 

--- a/lib/SemanticWeb/Schema/LoanOrCredit.pm
+++ b/lib/SemanticWeb/Schema/LoanOrCredit.pm
@@ -51,7 +51,7 @@ A amount should be one of the following types:
 
 has amount => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_amount',
     json_ld   => 'amount',
 );
 
@@ -86,7 +86,7 @@ A currency should be one of the following types:
 
 has currency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_currency',
     json_ld   => 'currency',
 );
 
@@ -111,7 +111,7 @@ A grace_period should be one of the following types:
 
 has grace_period => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_grace_period',
     json_ld   => 'gracePeriod',
 );
 
@@ -137,7 +137,7 @@ A loan_repayment_form should be one of the following types:
 
 has loan_repayment_form => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_loan_repayment_form',
     json_ld   => 'loanRepaymentForm',
 );
 
@@ -161,7 +161,7 @@ A loan_term should be one of the following types:
 
 has loan_term => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_loan_term',
     json_ld   => 'loanTerm',
 );
 
@@ -185,7 +185,7 @@ A loan_type should be one of the following types:
 
 has loan_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_loan_type',
     json_ld   => 'loanType',
 );
 
@@ -211,7 +211,7 @@ A recourse_loan should be one of the following types:
 
 has recourse_loan => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recourse_loan',
     json_ld   => 'recourseLoan',
 );
 
@@ -236,7 +236,7 @@ A renegotiable_loan should be one of the following types:
 
 has renegotiable_loan => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_renegotiable_loan',
     json_ld   => 'renegotiableLoan',
 );
 
@@ -263,7 +263,7 @@ A required_collateral should be one of the following types:
 
 has required_collateral => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_required_collateral',
     json_ld   => 'requiredCollateral',
 );
 

--- a/lib/SemanticWeb/Schema/LocalBusiness.pm
+++ b/lib/SemanticWeb/Schema/LocalBusiness.pm
@@ -57,7 +57,7 @@ A branch_of should be one of the following types:
 
 has branch_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_branch_of',
     json_ld   => 'branchOf',
 );
 
@@ -92,7 +92,7 @@ A currencies_accepted should be one of the following types:
 
 has currencies_accepted => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_currencies_accepted',
     json_ld   => 'currenciesAccepted',
 );
 
@@ -133,7 +133,7 @@ A opening_hours should be one of the following types:
 
 has opening_hours => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_opening_hours',
     json_ld   => 'openingHours',
 );
 
@@ -157,7 +157,7 @@ A payment_accepted should be one of the following types:
 
 has payment_accepted => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_payment_accepted',
     json_ld   => 'paymentAccepted',
 );
 
@@ -185,7 +185,7 @@ A price_range should be one of the following types:
 
 has price_range => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price_range',
     json_ld   => 'priceRange',
 );
 

--- a/lib/SemanticWeb/Schema/LocationFeatureSpecification.pm
+++ b/lib/SemanticWeb/Schema/LocationFeatureSpecification.pm
@@ -50,7 +50,7 @@ A hours_available should be one of the following types:
 
 has hours_available => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_hours_available',
     json_ld   => 'hoursAvailable',
 );
 
@@ -74,7 +74,7 @@ A valid_from should be one of the following types:
 
 has valid_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_from',
     json_ld   => 'validFrom',
 );
 
@@ -99,7 +99,7 @@ A valid_through should be one of the following types:
 
 has valid_through => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_through',
     json_ld   => 'validThrough',
 );
 

--- a/lib/SemanticWeb/Schema/LodgingBusiness.pm
+++ b/lib/SemanticWeb/Schema/LodgingBusiness.pm
@@ -51,7 +51,7 @@ A amenity_feature should be one of the following types:
 
 has amenity_feature => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_amenity_feature',
     json_ld   => 'amenityFeature',
 );
 
@@ -75,7 +75,7 @@ A audience should be one of the following types:
 
 has audience => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_audience',
     json_ld   => 'audience',
 );
 
@@ -108,7 +108,7 @@ A available_language should be one of the following types:
 
 has available_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_language',
     json_ld   => 'availableLanguage',
 );
 
@@ -132,7 +132,7 @@ A checkin_time should be one of the following types:
 
 has checkin_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_checkin_time',
     json_ld   => 'checkinTime',
 );
 
@@ -156,7 +156,7 @@ A checkout_time should be one of the following types:
 
 has checkout_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_checkout_time',
     json_ld   => 'checkoutTime',
 );
 
@@ -185,7 +185,7 @@ A number_of_rooms should be one of the following types:
 
 has number_of_rooms => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_rooms',
     json_ld   => 'numberOfRooms',
 );
 
@@ -212,7 +212,7 @@ A pets_allowed should be one of the following types:
 
 has pets_allowed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pets_allowed',
     json_ld   => 'petsAllowed',
 );
 
@@ -239,7 +239,7 @@ A star_rating should be one of the following types:
 
 has star_rating => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_star_rating',
     json_ld   => 'starRating',
 );
 

--- a/lib/SemanticWeb/Schema/LodgingReservation.pm
+++ b/lib/SemanticWeb/Schema/LodgingReservation.pm
@@ -55,7 +55,7 @@ A checkin_time should be one of the following types:
 
 has checkin_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_checkin_time',
     json_ld   => 'checkinTime',
 );
 
@@ -79,7 +79,7 @@ A checkout_time should be one of the following types:
 
 has checkout_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_checkout_time',
     json_ld   => 'checkoutTime',
 );
 
@@ -103,7 +103,7 @@ A lodging_unit_description should be one of the following types:
 
 has lodging_unit_description => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_lodging_unit_description',
     json_ld   => 'lodgingUnitDescription',
 );
 
@@ -130,7 +130,7 @@ A lodging_unit_type should be one of the following types:
 
 has lodging_unit_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_lodging_unit_type',
     json_ld   => 'lodgingUnitType',
 );
 
@@ -156,7 +156,7 @@ A num_adults should be one of the following types:
 
 has num_adults => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_num_adults',
     json_ld   => 'numAdults',
 );
 
@@ -182,7 +182,7 @@ A num_children should be one of the following types:
 
 has num_children => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_num_children',
     json_ld   => 'numChildren',
 );
 

--- a/lib/SemanticWeb/Schema/LoseAction.pm
+++ b/lib/SemanticWeb/Schema/LoseAction.pm
@@ -48,7 +48,7 @@ A winner should be one of the following types:
 
 has winner => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_winner',
     json_ld   => 'winner',
 );
 

--- a/lib/SemanticWeb/Schema/LymphaticVessel.pm
+++ b/lib/SemanticWeb/Schema/LymphaticVessel.pm
@@ -49,7 +49,7 @@ A originates_from should be one of the following types:
 
 has originates_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_originates_from',
     json_ld   => 'originatesFrom',
 );
 
@@ -76,7 +76,7 @@ A region_drained should be one of the following types:
 
 has region_drained => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_region_drained',
     json_ld   => 'regionDrained',
 );
 
@@ -100,7 +100,7 @@ A runs_to should be one of the following types:
 
 has runs_to => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_runs_to',
     json_ld   => 'runsTo',
 );
 

--- a/lib/SemanticWeb/Schema/Map.pm
+++ b/lib/SemanticWeb/Schema/Map.pm
@@ -48,7 +48,7 @@ A map_type should be one of the following types:
 
 has map_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_map_type',
     json_ld   => 'mapType',
 );
 

--- a/lib/SemanticWeb/Schema/MediaObject.pm
+++ b/lib/SemanticWeb/Schema/MediaObject.pm
@@ -52,7 +52,7 @@ A associated_article should be one of the following types:
 
 has associated_article => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_associated_article',
     json_ld   => 'associatedArticle',
 );
 
@@ -76,7 +76,7 @@ A bitrate should be one of the following types:
 
 has bitrate => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_bitrate',
     json_ld   => 'bitrate',
 );
 
@@ -100,7 +100,7 @@ A content_size should be one of the following types:
 
 has content_size => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_content_size',
     json_ld   => 'contentSize',
 );
 
@@ -124,7 +124,7 @@ A content_url should be one of the following types:
 
 has content_url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_content_url',
     json_ld   => 'contentUrl',
 );
 
@@ -153,7 +153,7 @@ A duration should be one of the following types:
 
 has duration => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_duration',
     json_ld   => 'duration',
 );
 
@@ -183,7 +183,7 @@ A embed_url should be one of the following types:
 
 has embed_url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_embed_url',
     json_ld   => 'embedUrl',
 );
 
@@ -207,7 +207,7 @@ A encodes_creative_work should be one of the following types:
 
 has encodes_creative_work => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_encodes_creative_work',
     json_ld   => 'encodesCreativeWork',
 );
 
@@ -249,7 +249,7 @@ A encoding_format should be one of the following types:
 
 has encoding_format => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_encoding_format',
     json_ld   => 'encodingFormat',
 );
 
@@ -284,7 +284,7 @@ A end_time should be one of the following types:
 
 has end_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_end_time',
     json_ld   => 'endTime',
 );
 
@@ -310,7 +310,7 @@ A height should be one of the following types:
 
 has height => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_height',
     json_ld   => 'height',
 );
 
@@ -334,7 +334,7 @@ A player_type should be one of the following types:
 
 has player_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_player_type',
     json_ld   => 'playerType',
 );
 
@@ -359,7 +359,7 @@ A production_company should be one of the following types:
 
 has production_company => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_production_company',
     json_ld   => 'productionCompany',
 );
 
@@ -389,7 +389,7 @@ A regions_allowed should be one of the following types:
 
 has regions_allowed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_regions_allowed',
     json_ld   => 'regionsAllowed',
 );
 
@@ -421,7 +421,7 @@ A requires_subscription should be one of the following types:
 
 has requires_subscription => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_requires_subscription',
     json_ld   => 'requiresSubscription',
 );
 
@@ -456,7 +456,7 @@ A start_time should be one of the following types:
 
 has start_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_start_time',
     json_ld   => 'startTime',
 );
 
@@ -480,7 +480,7 @@ A upload_date should be one of the following types:
 
 has upload_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_upload_date',
     json_ld   => 'uploadDate',
 );
 
@@ -506,7 +506,7 @@ A width should be one of the following types:
 
 has width => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_width',
     json_ld   => 'width',
 );
 

--- a/lib/SemanticWeb/Schema/MediaSubscription.pm
+++ b/lib/SemanticWeb/Schema/MediaSubscription.pm
@@ -51,7 +51,7 @@ A authenticator should be one of the following types:
 
 has authenticator => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_authenticator',
     json_ld   => 'authenticator',
 );
 
@@ -76,7 +76,7 @@ A expects_acceptance_of should be one of the following types:
 
 has expects_acceptance_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_expects_acceptance_of',
     json_ld   => 'expectsAcceptanceOf',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalCause.pm
+++ b/lib/SemanticWeb/Schema/MedicalCause.pm
@@ -63,7 +63,7 @@ A cause_of should be one of the following types:
 
 has cause_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cause_of',
     json_ld   => 'causeOf',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalClinic.pm
+++ b/lib/SemanticWeb/Schema/MedicalClinic.pm
@@ -54,7 +54,7 @@ A available_service should be one of the following types:
 
 has available_service => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_service',
     json_ld   => 'availableService',
 );
 
@@ -78,7 +78,7 @@ A medical_specialty should be one of the following types:
 
 has medical_specialty => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_medical_specialty',
     json_ld   => 'medicalSpecialty',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalCode.pm
+++ b/lib/SemanticWeb/Schema/MedicalCode.pm
@@ -48,7 +48,7 @@ A code_value should be one of the following types:
 
 has code_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_code_value',
     json_ld   => 'codeValue',
 );
 
@@ -72,7 +72,7 @@ A coding_system should be one of the following types:
 
 has coding_system => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_coding_system',
     json_ld   => 'codingSystem',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalCondition.pm
+++ b/lib/SemanticWeb/Schema/MedicalCondition.pm
@@ -55,7 +55,7 @@ A associated_anatomy should be one of the following types:
 
 has associated_anatomy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_associated_anatomy',
     json_ld   => 'associatedAnatomy',
 );
 
@@ -81,7 +81,7 @@ A cause should be one of the following types:
 
 has cause => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cause',
     json_ld   => 'cause',
 );
 
@@ -110,7 +110,7 @@ A differential_diagnosis should be one of the following types:
 
 has differential_diagnosis => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_differential_diagnosis',
     json_ld   => 'differentialDiagnosis',
 );
 
@@ -134,7 +134,7 @@ A drug should be one of the following types:
 
 has drug => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_drug',
     json_ld   => 'drug',
 );
 
@@ -158,7 +158,7 @@ A epidemiology should be one of the following types:
 
 has epidemiology => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_epidemiology',
     json_ld   => 'epidemiology',
 );
 
@@ -183,7 +183,7 @@ A expected_prognosis should be one of the following types:
 
 has expected_prognosis => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_expected_prognosis',
     json_ld   => 'expectedPrognosis',
 );
 
@@ -208,7 +208,7 @@ A natural_progression should be one of the following types:
 
 has natural_progression => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_natural_progression',
     json_ld   => 'naturalProgression',
 );
 
@@ -233,7 +233,7 @@ A pathophysiology should be one of the following types:
 
 has pathophysiology => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pathophysiology',
     json_ld   => 'pathophysiology',
 );
 
@@ -259,7 +259,7 @@ A possible_complication should be one of the following types:
 
 has possible_complication => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_possible_complication',
     json_ld   => 'possibleComplication',
 );
 
@@ -283,7 +283,7 @@ A possible_treatment should be one of the following types:
 
 has possible_treatment => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_possible_treatment',
     json_ld   => 'possibleTreatment',
 );
 
@@ -308,7 +308,7 @@ A primary_prevention should be one of the following types:
 
 has primary_prevention => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_primary_prevention',
     json_ld   => 'primaryPrevention',
 );
 
@@ -333,7 +333,7 @@ A risk_factor should be one of the following types:
 
 has risk_factor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_risk_factor',
     json_ld   => 'riskFactor',
 );
 
@@ -358,7 +358,7 @@ A secondary_prevention should be one of the following types:
 
 has secondary_prevention => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_secondary_prevention',
     json_ld   => 'secondaryPrevention',
 );
 
@@ -384,7 +384,7 @@ A sign_or_symptom should be one of the following types:
 
 has sign_or_symptom => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sign_or_symptom',
     json_ld   => 'signOrSymptom',
 );
 
@@ -408,7 +408,7 @@ A stage should be one of the following types:
 
 has stage => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_stage',
     json_ld   => 'stage',
 );
 
@@ -436,7 +436,7 @@ A status should be one of the following types:
 
 has status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_status',
     json_ld   => 'status',
 );
 
@@ -461,7 +461,7 @@ A subtype should be one of the following types:
 
 has subtype => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_subtype',
     json_ld   => 'subtype',
 );
 
@@ -485,7 +485,7 @@ A typical_test should be one of the following types:
 
 has typical_test => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_typical_test',
     json_ld   => 'typicalTest',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalConditionStage.pm
+++ b/lib/SemanticWeb/Schema/MedicalConditionStage.pm
@@ -48,7 +48,7 @@ A stage_as_number should be one of the following types:
 
 has stage_as_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_stage_as_number',
     json_ld   => 'stageAsNumber',
 );
 
@@ -72,7 +72,7 @@ A sub_stage_suffix should be one of the following types:
 
 has sub_stage_suffix => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sub_stage_suffix',
     json_ld   => 'subStageSuffix',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalDevice.pm
+++ b/lib/SemanticWeb/Schema/MedicalDevice.pm
@@ -53,7 +53,7 @@ A adverse_outcome should be one of the following types:
 
 has adverse_outcome => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_adverse_outcome',
     json_ld   => 'adverseOutcome',
 );
 
@@ -79,7 +79,7 @@ A contraindication should be one of the following types:
 
 has contraindication => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contraindication',
     json_ld   => 'contraindication',
 );
 
@@ -107,7 +107,7 @@ A indication should be one of the following types:
 
 has indication => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_indication',
     json_ld   => 'indication',
 );
 
@@ -132,7 +132,7 @@ A post_op should be one of the following types:
 
 has post_op => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_post_op',
     json_ld   => 'postOp',
 );
 
@@ -157,7 +157,7 @@ A pre_op should be one of the following types:
 
 has pre_op => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pre_op',
     json_ld   => 'preOp',
 );
 
@@ -182,7 +182,7 @@ A procedure should be one of the following types:
 
 has procedure => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_procedure',
     json_ld   => 'procedure',
 );
 
@@ -208,7 +208,7 @@ A purpose should be one of the following types:
 
 has purpose => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_purpose',
     json_ld   => 'purpose',
 );
 
@@ -237,7 +237,7 @@ A serious_adverse_outcome should be one of the following types:
 
 has serious_adverse_outcome => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_serious_adverse_outcome',
     json_ld   => 'seriousAdverseOutcome',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalEntity.pm
+++ b/lib/SemanticWeb/Schema/MedicalEntity.pm
@@ -50,7 +50,7 @@ A code should be one of the following types:
 
 has code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_code',
     json_ld   => 'code',
 );
 
@@ -74,7 +74,7 @@ A guideline should be one of the following types:
 
 has guideline => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_guideline',
     json_ld   => 'guideline',
 );
 
@@ -103,7 +103,7 @@ A legal_status should be one of the following types:
 
 has legal_status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legal_status',
     json_ld   => 'legalStatus',
 );
 
@@ -128,7 +128,7 @@ A medicine_system should be one of the following types:
 
 has medicine_system => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_medicine_system',
     json_ld   => 'medicineSystem',
 );
 
@@ -153,7 +153,7 @@ A recognizing_authority should be one of the following types:
 
 has recognizing_authority => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recognizing_authority',
     json_ld   => 'recognizingAuthority',
 );
 
@@ -177,7 +177,7 @@ A relevant_specialty should be one of the following types:
 
 has relevant_specialty => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_relevant_specialty',
     json_ld   => 'relevantSpecialty',
 );
 
@@ -201,7 +201,7 @@ A study should be one of the following types:
 
 has study => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_study',
     json_ld   => 'study',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalGuideline.pm
+++ b/lib/SemanticWeb/Schema/MedicalGuideline.pm
@@ -55,7 +55,7 @@ A evidence_level should be one of the following types:
 
 has evidence_level => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_evidence_level',
     json_ld   => 'evidenceLevel',
 );
 
@@ -80,7 +80,7 @@ A evidence_origin should be one of the following types:
 
 has evidence_origin => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_evidence_origin',
     json_ld   => 'evidenceOrigin',
 );
 
@@ -104,7 +104,7 @@ A guideline_date should be one of the following types:
 
 has guideline_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_guideline_date',
     json_ld   => 'guidelineDate',
 );
 
@@ -129,7 +129,7 @@ A guideline_subject should be one of the following types:
 
 has guideline_subject => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_guideline_subject',
     json_ld   => 'guidelineSubject',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalGuidelineRecommendation.pm
+++ b/lib/SemanticWeb/Schema/MedicalGuidelineRecommendation.pm
@@ -49,7 +49,7 @@ A recommendation_strength should be one of the following types:
 
 has recommendation_strength => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recommendation_strength',
     json_ld   => 'recommendationStrength',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalObservationalStudy.pm
+++ b/lib/SemanticWeb/Schema/MedicalObservationalStudy.pm
@@ -55,7 +55,7 @@ A study_design should be one of the following types:
 
 has study_design => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_study_design',
     json_ld   => 'studyDesign',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalOrganization.pm
+++ b/lib/SemanticWeb/Schema/MedicalOrganization.pm
@@ -50,7 +50,7 @@ A health_plan_network_id should be one of the following types:
 
 has health_plan_network_id => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_plan_network_id',
     json_ld   => 'healthPlanNetworkId',
 );
 
@@ -74,7 +74,7 @@ A is_accepting_new_patients should be one of the following types:
 
 has is_accepting_new_patients => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_accepting_new_patients',
     json_ld   => 'isAcceptingNewPatients',
 );
 
@@ -98,7 +98,7 @@ A medical_specialty should be one of the following types:
 
 has medical_specialty => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_medical_specialty',
     json_ld   => 'medicalSpecialty',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalProcedure.pm
+++ b/lib/SemanticWeb/Schema/MedicalProcedure.pm
@@ -50,7 +50,7 @@ A body_location should be one of the following types:
 
 has body_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_body_location',
     json_ld   => 'bodyLocation',
 );
 
@@ -74,7 +74,7 @@ A followup should be one of the following types:
 
 has followup => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_followup',
     json_ld   => 'followup',
 );
 
@@ -98,7 +98,7 @@ A how_performed should be one of the following types:
 
 has how_performed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_how_performed',
     json_ld   => 'howPerformed',
 );
 
@@ -126,7 +126,7 @@ A indication should be one of the following types:
 
 has indication => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_indication',
     json_ld   => 'indication',
 );
 
@@ -152,7 +152,7 @@ A outcome should be one of the following types:
 
 has outcome => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_outcome',
     json_ld   => 'outcome',
 );
 
@@ -179,7 +179,7 @@ A preparation should be one of the following types:
 
 has preparation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_preparation',
     json_ld   => 'preparation',
 );
 
@@ -203,7 +203,7 @@ A procedure_type should be one of the following types:
 
 has procedure_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_procedure_type',
     json_ld   => 'procedureType',
 );
 
@@ -231,7 +231,7 @@ A status should be one of the following types:
 
 has status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_status',
     json_ld   => 'status',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalRiskEstimator.pm
+++ b/lib/SemanticWeb/Schema/MedicalRiskEstimator.pm
@@ -49,7 +49,7 @@ A estimates_risk_of should be one of the following types:
 
 has estimates_risk_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_estimates_risk_of',
     json_ld   => 'estimatesRiskOf',
 );
 
@@ -74,7 +74,7 @@ A included_risk_factor should be one of the following types:
 
 has included_risk_factor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_included_risk_factor',
     json_ld   => 'includedRiskFactor',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalRiskFactor.pm
+++ b/lib/SemanticWeb/Schema/MedicalRiskFactor.pm
@@ -49,7 +49,7 @@ A increases_risk_of should be one of the following types:
 
 has increases_risk_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_increases_risk_of',
     json_ld   => 'increasesRiskOf',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalRiskScore.pm
+++ b/lib/SemanticWeb/Schema/MedicalRiskScore.pm
@@ -49,7 +49,7 @@ A algorithm should be one of the following types:
 
 has algorithm => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_algorithm',
     json_ld   => 'algorithm',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalScholarlyArticle.pm
+++ b/lib/SemanticWeb/Schema/MedicalScholarlyArticle.pm
@@ -54,7 +54,7 @@ A publication_type should be one of the following types:
 
 has publication_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_publication_type',
     json_ld   => 'publicationType',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalSign.pm
+++ b/lib/SemanticWeb/Schema/MedicalSign.pm
@@ -49,7 +49,7 @@ A identifying_exam should be one of the following types:
 
 has identifying_exam => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_identifying_exam',
     json_ld   => 'identifyingExam',
 );
 
@@ -73,7 +73,7 @@ A identifying_test should be one of the following types:
 
 has identifying_test => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_identifying_test',
     json_ld   => 'identifyingTest',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalSignOrSymptom.pm
+++ b/lib/SemanticWeb/Schema/MedicalSignOrSymptom.pm
@@ -51,7 +51,7 @@ A cause should be one of the following types:
 
 has cause => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cause',
     json_ld   => 'cause',
 );
 
@@ -75,7 +75,7 @@ A possible_treatment should be one of the following types:
 
 has possible_treatment => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_possible_treatment',
     json_ld   => 'possibleTreatment',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalStudy.pm
+++ b/lib/SemanticWeb/Schema/MedicalStudy.pm
@@ -57,7 +57,7 @@ A health_condition should be one of the following types:
 
 has health_condition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_condition',
     json_ld   => 'healthCondition',
 );
 
@@ -83,7 +83,7 @@ A outcome should be one of the following types:
 
 has outcome => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_outcome',
     json_ld   => 'outcome',
 );
 
@@ -108,7 +108,7 @@ A population should be one of the following types:
 
 has population => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_population',
     json_ld   => 'population',
 );
 
@@ -136,7 +136,7 @@ A sponsor should be one of the following types:
 
 has sponsor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sponsor',
     json_ld   => 'sponsor',
 );
 
@@ -164,7 +164,7 @@ A status should be one of the following types:
 
 has status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_status',
     json_ld   => 'status',
 );
 
@@ -188,7 +188,7 @@ A study_location should be one of the following types:
 
 has study_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_study_location',
     json_ld   => 'studyLocation',
 );
 
@@ -213,7 +213,7 @@ A study_subject should be one of the following types:
 
 has study_subject => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_study_subject',
     json_ld   => 'studySubject',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalTest.pm
+++ b/lib/SemanticWeb/Schema/MedicalTest.pm
@@ -48,7 +48,7 @@ A affected_by should be one of the following types:
 
 has affected_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_affected_by',
     json_ld   => 'affectedBy',
 );
 
@@ -74,7 +74,7 @@ A normal_range should be one of the following types:
 
 has normal_range => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_normal_range',
     json_ld   => 'normalRange',
 );
 
@@ -98,7 +98,7 @@ A sign_detected should be one of the following types:
 
 has sign_detected => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sign_detected',
     json_ld   => 'signDetected',
 );
 
@@ -122,7 +122,7 @@ A used_to_diagnose should be one of the following types:
 
 has used_to_diagnose => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_used_to_diagnose',
     json_ld   => 'usedToDiagnose',
 );
 
@@ -146,7 +146,7 @@ A uses_device should be one of the following types:
 
 has uses_device => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_uses_device',
     json_ld   => 'usesDevice',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalTestPanel.pm
+++ b/lib/SemanticWeb/Schema/MedicalTestPanel.pm
@@ -48,7 +48,7 @@ A sub_test should be one of the following types:
 
 has sub_test => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sub_test',
     json_ld   => 'subTest',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalTherapy.pm
+++ b/lib/SemanticWeb/Schema/MedicalTherapy.pm
@@ -55,7 +55,7 @@ A contraindication should be one of the following types:
 
 has contraindication => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contraindication',
     json_ld   => 'contraindication',
 );
 
@@ -79,7 +79,7 @@ A duplicate_therapy should be one of the following types:
 
 has duplicate_therapy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_duplicate_therapy',
     json_ld   => 'duplicateTherapy',
 );
 
@@ -108,7 +108,7 @@ A serious_adverse_outcome should be one of the following types:
 
 has serious_adverse_outcome => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_serious_adverse_outcome',
     json_ld   => 'seriousAdverseOutcome',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalTrial.pm
+++ b/lib/SemanticWeb/Schema/MedicalTrial.pm
@@ -51,7 +51,7 @@ A phase should be one of the following types:
 
 has phase => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_phase',
     json_ld   => 'phase',
 );
 
@@ -75,7 +75,7 @@ A trial_design should be one of the following types:
 
 has trial_design => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_trial_design',
     json_ld   => 'trialDesign',
 );
 

--- a/lib/SemanticWeb/Schema/MedicalWebPage.pm
+++ b/lib/SemanticWeb/Schema/MedicalWebPage.pm
@@ -50,7 +50,7 @@ A aspect should be one of the following types:
 
 has aspect => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_aspect',
     json_ld   => 'aspect',
 );
 

--- a/lib/SemanticWeb/Schema/Menu.pm
+++ b/lib/SemanticWeb/Schema/Menu.pm
@@ -49,7 +49,7 @@ A has_menu_item should be one of the following types:
 
 has has_menu_item => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_menu_item',
     json_ld   => 'hasMenuItem',
 );
 
@@ -73,7 +73,7 @@ A has_menu_section should be one of the following types:
 
 has has_menu_section => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_menu_section',
     json_ld   => 'hasMenuSection',
 );
 

--- a/lib/SemanticWeb/Schema/MenuItem.pm
+++ b/lib/SemanticWeb/Schema/MenuItem.pm
@@ -52,7 +52,7 @@ A menu_add_on should be one of the following types:
 
 has menu_add_on => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_menu_add_on',
     json_ld   => 'menuAddOn',
 );
 
@@ -76,7 +76,7 @@ A nutrition should be one of the following types:
 
 has nutrition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_nutrition',
     json_ld   => 'nutrition',
 );
 
@@ -102,7 +102,7 @@ A offers should be one of the following types:
 
 has offers => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_offers',
     json_ld   => 'offers',
 );
 
@@ -127,7 +127,7 @@ A suitable_for_diet should be one of the following types:
 
 has suitable_for_diet => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_suitable_for_diet',
     json_ld   => 'suitableForDiet',
 );
 

--- a/lib/SemanticWeb/Schema/MenuSection.pm
+++ b/lib/SemanticWeb/Schema/MenuSection.pm
@@ -51,7 +51,7 @@ A has_menu_item should be one of the following types:
 
 has has_menu_item => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_menu_item',
     json_ld   => 'hasMenuItem',
 );
 
@@ -75,7 +75,7 @@ A has_menu_section should be one of the following types:
 
 has has_menu_section => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_menu_section',
     json_ld   => 'hasMenuSection',
 );
 

--- a/lib/SemanticWeb/Schema/Message.pm
+++ b/lib/SemanticWeb/Schema/Message.pm
@@ -52,7 +52,7 @@ A bcc_recipient should be one of the following types:
 
 has bcc_recipient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_bcc_recipient',
     json_ld   => 'bccRecipient',
 );
 
@@ -80,7 +80,7 @@ A cc_recipient should be one of the following types:
 
 has cc_recipient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cc_recipient',
     json_ld   => 'ccRecipient',
 );
 
@@ -105,7 +105,7 @@ A date_read should be one of the following types:
 
 has date_read => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_date_read',
     json_ld   => 'dateRead',
 );
 
@@ -129,7 +129,7 @@ A date_received should be one of the following types:
 
 has date_received => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_date_received',
     json_ld   => 'dateReceived',
 );
 
@@ -153,7 +153,7 @@ A date_sent should be one of the following types:
 
 has date_sent => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_date_sent',
     json_ld   => 'dateSent',
 );
 
@@ -177,7 +177,7 @@ A message_attachment should be one of the following types:
 
 has message_attachment => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_message_attachment',
     json_ld   => 'messageAttachment',
 );
 
@@ -208,7 +208,7 @@ A recipient should be one of the following types:
 
 has recipient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipient',
     json_ld   => 'recipient',
 );
 
@@ -237,7 +237,7 @@ A sender should be one of the following types:
 
 has sender => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sender',
     json_ld   => 'sender',
 );
 
@@ -268,7 +268,7 @@ A to_recipient should be one of the following types:
 
 has to_recipient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_to_recipient',
     json_ld   => 'toRecipient',
 );
 

--- a/lib/SemanticWeb/Schema/MobileApplication.pm
+++ b/lib/SemanticWeb/Schema/MobileApplication.pm
@@ -50,7 +50,7 @@ A carrier_requirements should be one of the following types:
 
 has carrier_requirements => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_carrier_requirements',
     json_ld   => 'carrierRequirements',
 );
 

--- a/lib/SemanticWeb/Schema/MonetaryAmount.pm
+++ b/lib/SemanticWeb/Schema/MonetaryAmount.pm
@@ -68,7 +68,7 @@ A currency should be one of the following types:
 
 has currency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_currency',
     json_ld   => 'currency',
 );
 
@@ -92,7 +92,7 @@ A max_value should be one of the following types:
 
 has max_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_max_value',
     json_ld   => 'maxValue',
 );
 
@@ -116,7 +116,7 @@ A min_value should be one of the following types:
 
 has min_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_min_value',
     json_ld   => 'minValue',
 );
 
@@ -140,7 +140,7 @@ A valid_from should be one of the following types:
 
 has valid_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_from',
     json_ld   => 'validFrom',
 );
 
@@ -165,7 +165,7 @@ A valid_through should be one of the following types:
 
 has valid_through => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_through',
     json_ld   => 'validThrough',
 );
 
@@ -210,7 +210,7 @@ A value should be one of the following types:
 
 has value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_value',
     json_ld   => 'value',
 );
 

--- a/lib/SemanticWeb/Schema/MonetaryAmountDistribution.pm
+++ b/lib/SemanticWeb/Schema/MonetaryAmountDistribution.pm
@@ -59,7 +59,7 @@ A currency should be one of the following types:
 
 has currency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_currency',
     json_ld   => 'currency',
 );
 

--- a/lib/SemanticWeb/Schema/MonetaryGrant.pm
+++ b/lib/SemanticWeb/Schema/MonetaryGrant.pm
@@ -50,7 +50,7 @@ A amount should be one of the following types:
 
 has amount => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_amount',
     json_ld   => 'amount',
 );
 
@@ -77,7 +77,7 @@ A funder should be one of the following types:
 
 has funder => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_funder',
     json_ld   => 'funder',
 );
 

--- a/lib/SemanticWeb/Schema/MoneyTransfer.pm
+++ b/lib/SemanticWeb/Schema/MoneyTransfer.pm
@@ -51,7 +51,7 @@ A amount should be one of the following types:
 
 has amount => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_amount',
     json_ld   => 'amount',
 );
 
@@ -79,7 +79,7 @@ A beneficiary_bank should be one of the following types:
 
 has beneficiary_bank => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_beneficiary_bank',
     json_ld   => 'beneficiaryBank',
 );
 

--- a/lib/SemanticWeb/Schema/MortgageLoan.pm
+++ b/lib/SemanticWeb/Schema/MortgageLoan.pm
@@ -50,7 +50,7 @@ A domiciled_mortgage should be one of the following types:
 
 has domiciled_mortgage => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_domiciled_mortgage',
     json_ld   => 'domiciledMortgage',
 );
 
@@ -75,7 +75,7 @@ A loan_mortgage_mandate_amount should be one of the following types:
 
 has loan_mortgage_mandate_amount => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_loan_mortgage_mandate_amount',
     json_ld   => 'loanMortgageMandateAmount',
 );
 

--- a/lib/SemanticWeb/Schema/MoveAction.pm
+++ b/lib/SemanticWeb/Schema/MoveAction.pm
@@ -57,7 +57,7 @@ A from_location should be one of the following types:
 
 has from_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_from_location',
     json_ld   => 'fromLocation',
 );
 
@@ -82,7 +82,7 @@ A to_location should be one of the following types:
 
 has to_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_to_location',
     json_ld   => 'toLocation',
 );
 

--- a/lib/SemanticWeb/Schema/Movie.pm
+++ b/lib/SemanticWeb/Schema/Movie.pm
@@ -50,7 +50,7 @@ A actor should be one of the following types:
 
 has actor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actor',
     json_ld   => 'actor',
 );
 
@@ -75,7 +75,7 @@ A actors should be one of the following types:
 
 has actors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actors',
     json_ld   => 'actors',
 );
 
@@ -100,7 +100,7 @@ A country_of_origin should be one of the following types:
 
 has country_of_origin => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_country_of_origin',
     json_ld   => 'countryOfOrigin',
 );
 
@@ -126,7 +126,7 @@ A director should be one of the following types:
 
 has director => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_director',
     json_ld   => 'director',
 );
 
@@ -151,7 +151,7 @@ A directors should be one of the following types:
 
 has directors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_directors',
     json_ld   => 'directors',
 );
 
@@ -180,7 +180,7 @@ A duration should be one of the following types:
 
 has duration => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_duration',
     json_ld   => 'duration',
 );
 
@@ -206,7 +206,7 @@ A music_by should be one of the following types:
 
 has music_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_music_by',
     json_ld   => 'musicBy',
 );
 
@@ -231,7 +231,7 @@ A production_company should be one of the following types:
 
 has production_company => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_production_company',
     json_ld   => 'productionCompany',
 );
 
@@ -262,7 +262,7 @@ A subtitle_language should be one of the following types:
 
 has subtitle_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_subtitle_language',
     json_ld   => 'subtitleLanguage',
 );
 
@@ -286,7 +286,7 @@ A trailer should be one of the following types:
 
 has trailer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_trailer',
     json_ld   => 'trailer',
 );
 

--- a/lib/SemanticWeb/Schema/MovieSeries.pm
+++ b/lib/SemanticWeb/Schema/MovieSeries.pm
@@ -51,7 +51,7 @@ A actor should be one of the following types:
 
 has actor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actor',
     json_ld   => 'actor',
 );
 
@@ -76,7 +76,7 @@ A actors should be one of the following types:
 
 has actors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actors',
     json_ld   => 'actors',
 );
 
@@ -102,7 +102,7 @@ A director should be one of the following types:
 
 has director => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_director',
     json_ld   => 'director',
 );
 
@@ -127,7 +127,7 @@ A directors should be one of the following types:
 
 has directors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_directors',
     json_ld   => 'directors',
 );
 
@@ -153,7 +153,7 @@ A music_by should be one of the following types:
 
 has music_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_music_by',
     json_ld   => 'musicBy',
 );
 
@@ -178,7 +178,7 @@ A production_company should be one of the following types:
 
 has production_company => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_production_company',
     json_ld   => 'productionCompany',
 );
 
@@ -202,7 +202,7 @@ A trailer should be one of the following types:
 
 has trailer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_trailer',
     json_ld   => 'trailer',
 );
 

--- a/lib/SemanticWeb/Schema/MovieTheater.pm
+++ b/lib/SemanticWeb/Schema/MovieTheater.pm
@@ -48,7 +48,7 @@ A screen_count should be one of the following types:
 
 has screen_count => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_screen_count',
     json_ld   => 'screenCount',
 );
 

--- a/lib/SemanticWeb/Schema/Muscle.pm
+++ b/lib/SemanticWeb/Schema/Muscle.pm
@@ -56,7 +56,7 @@ A action should be one of the following types:
 
 has action => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_action',
     json_ld   => 'action',
 );
 
@@ -80,7 +80,7 @@ A antagonist should be one of the following types:
 
 has antagonist => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_antagonist',
     json_ld   => 'antagonist',
 );
 
@@ -104,7 +104,7 @@ A blood_supply should be one of the following types:
 
 has blood_supply => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_blood_supply',
     json_ld   => 'bloodSupply',
 );
 
@@ -128,7 +128,7 @@ A insertion should be one of the following types:
 
 has insertion => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_insertion',
     json_ld   => 'insertion',
 );
 
@@ -152,7 +152,7 @@ A muscle_action should be one of the following types:
 
 has muscle_action => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_muscle_action',
     json_ld   => 'muscleAction',
 );
 
@@ -176,7 +176,7 @@ A nerve should be one of the following types:
 
 has nerve => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_nerve',
     json_ld   => 'nerve',
 );
 
@@ -200,7 +200,7 @@ A origin should be one of the following types:
 
 has origin => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_origin',
     json_ld   => 'origin',
 );
 

--- a/lib/SemanticWeb/Schema/MusicAlbum.pm
+++ b/lib/SemanticWeb/Schema/MusicAlbum.pm
@@ -49,7 +49,7 @@ A album_production_type should be one of the following types:
 
 has album_production_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_album_production_type',
     json_ld   => 'albumProductionType',
 );
 
@@ -73,7 +73,7 @@ A album_release should be one of the following types:
 
 has album_release => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_album_release',
     json_ld   => 'albumRelease',
 );
 
@@ -97,7 +97,7 @@ A album_release_type should be one of the following types:
 
 has album_release_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_album_release_type',
     json_ld   => 'albumReleaseType',
 );
 
@@ -123,7 +123,7 @@ A by_artist should be one of the following types:
 
 has by_artist => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_by_artist',
     json_ld   => 'byArtist',
 );
 

--- a/lib/SemanticWeb/Schema/MusicComposition.pm
+++ b/lib/SemanticWeb/Schema/MusicComposition.pm
@@ -51,7 +51,7 @@ A composer should be one of the following types:
 
 has composer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_composer',
     json_ld   => 'composer',
 );
 
@@ -75,7 +75,7 @@ A first_performance should be one of the following types:
 
 has first_performance => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_first_performance',
     json_ld   => 'firstPerformance',
 );
 
@@ -99,7 +99,7 @@ A included_composition should be one of the following types:
 
 has included_composition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_included_composition',
     json_ld   => 'includedComposition',
 );
 
@@ -123,7 +123,7 @@ A iswc_code should be one of the following types:
 
 has iswc_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_iswc_code',
     json_ld   => 'iswcCode',
 );
 
@@ -147,7 +147,7 @@ A lyricist should be one of the following types:
 
 has lyricist => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_lyricist',
     json_ld   => 'lyricist',
 );
 
@@ -171,7 +171,7 @@ A lyrics should be one of the following types:
 
 has lyrics => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_lyrics',
     json_ld   => 'lyrics',
 );
 
@@ -195,7 +195,7 @@ A music_arrangement should be one of the following types:
 
 has music_arrangement => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_music_arrangement',
     json_ld   => 'musicArrangement',
 );
 
@@ -219,7 +219,7 @@ A music_composition_form should be one of the following types:
 
 has music_composition_form => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_music_composition_form',
     json_ld   => 'musicCompositionForm',
 );
 
@@ -243,7 +243,7 @@ A musical_key should be one of the following types:
 
 has musical_key => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_musical_key',
     json_ld   => 'musicalKey',
 );
 
@@ -267,7 +267,7 @@ A recorded_as should be one of the following types:
 
 has recorded_as => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recorded_as',
     json_ld   => 'recordedAs',
 );
 

--- a/lib/SemanticWeb/Schema/MusicGroup.pm
+++ b/lib/SemanticWeb/Schema/MusicGroup.pm
@@ -49,7 +49,7 @@ A album should be one of the following types:
 
 has album => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_album',
     json_ld   => 'album',
 );
 
@@ -73,7 +73,7 @@ A albums should be one of the following types:
 
 has albums => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_albums',
     json_ld   => 'albums',
 );
 
@@ -97,7 +97,7 @@ A genre should be one of the following types:
 
 has genre => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_genre',
     json_ld   => 'genre',
 );
 
@@ -121,7 +121,7 @@ A music_group_member should be one of the following types:
 
 has music_group_member => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_music_group_member',
     json_ld   => 'musicGroupMember',
 );
 
@@ -148,7 +148,7 @@ A track should be one of the following types:
 
 has track => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_track',
     json_ld   => 'track',
 );
 
@@ -172,7 +172,7 @@ A tracks should be one of the following types:
 
 has tracks => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_tracks',
     json_ld   => 'tracks',
 );
 

--- a/lib/SemanticWeb/Schema/MusicPlaylist.pm
+++ b/lib/SemanticWeb/Schema/MusicPlaylist.pm
@@ -48,7 +48,7 @@ A num_tracks should be one of the following types:
 
 has num_tracks => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_num_tracks',
     json_ld   => 'numTracks',
 );
 
@@ -75,7 +75,7 @@ A track should be one of the following types:
 
 has track => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_track',
     json_ld   => 'track',
 );
 
@@ -99,7 +99,7 @@ A tracks should be one of the following types:
 
 has tracks => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_tracks',
     json_ld   => 'tracks',
 );
 

--- a/lib/SemanticWeb/Schema/MusicRecording.pm
+++ b/lib/SemanticWeb/Schema/MusicRecording.pm
@@ -50,7 +50,7 @@ A by_artist should be one of the following types:
 
 has by_artist => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_by_artist',
     json_ld   => 'byArtist',
 );
 
@@ -79,7 +79,7 @@ A duration should be one of the following types:
 
 has duration => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_duration',
     json_ld   => 'duration',
 );
 
@@ -103,7 +103,7 @@ A in_album should be one of the following types:
 
 has in_album => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_in_album',
     json_ld   => 'inAlbum',
 );
 
@@ -127,7 +127,7 @@ A in_playlist should be one of the following types:
 
 has in_playlist => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_in_playlist',
     json_ld   => 'inPlaylist',
 );
 
@@ -151,7 +151,7 @@ A isrc_code should be one of the following types:
 
 has isrc_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_isrc_code',
     json_ld   => 'isrcCode',
 );
 
@@ -175,7 +175,7 @@ A recording_of should be one of the following types:
 
 has recording_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recording_of',
     json_ld   => 'recordingOf',
 );
 

--- a/lib/SemanticWeb/Schema/MusicRelease.pm
+++ b/lib/SemanticWeb/Schema/MusicRelease.pm
@@ -48,7 +48,7 @@ A catalog_number should be one of the following types:
 
 has catalog_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_catalog_number',
     json_ld   => 'catalogNumber',
 );
 
@@ -76,7 +76,7 @@ A credited_to should be one of the following types:
 
 has credited_to => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_credited_to',
     json_ld   => 'creditedTo',
 );
 
@@ -105,7 +105,7 @@ A duration should be one of the following types:
 
 has duration => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_duration',
     json_ld   => 'duration',
 );
 
@@ -130,7 +130,7 @@ A music_release_format should be one of the following types:
 
 has music_release_format => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_music_release_format',
     json_ld   => 'musicReleaseFormat',
 );
 
@@ -154,7 +154,7 @@ A record_label should be one of the following types:
 
 has record_label => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_record_label',
     json_ld   => 'recordLabel',
 );
 
@@ -178,7 +178,7 @@ A release_of should be one of the following types:
 
 has release_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_release_of',
     json_ld   => 'releaseOf',
 );
 

--- a/lib/SemanticWeb/Schema/Nerve.pm
+++ b/lib/SemanticWeb/Schema/Nerve.pm
@@ -55,7 +55,7 @@ A branch should be one of the following types:
 
 has branch => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_branch',
     json_ld   => 'branch',
 );
 
@@ -79,7 +79,7 @@ A nerve_motor should be one of the following types:
 
 has nerve_motor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_nerve_motor',
     json_ld   => 'nerveMotor',
 );
 
@@ -106,7 +106,7 @@ A sensory_unit should be one of the following types:
 
 has sensory_unit => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sensory_unit',
     json_ld   => 'sensoryUnit',
 );
 
@@ -130,7 +130,7 @@ A sourced_from should be one of the following types:
 
 has sourced_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sourced_from',
     json_ld   => 'sourcedFrom',
 );
 

--- a/lib/SemanticWeb/Schema/NewsArticle.pm
+++ b/lib/SemanticWeb/Schema/NewsArticle.pm
@@ -72,7 +72,7 @@ A dateline should be one of the following types:
 
 has dateline => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_dateline',
     json_ld   => 'dateline',
 );
 
@@ -97,7 +97,7 @@ A print_column should be one of the following types:
 
 has print_column => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_print_column',
     json_ld   => 'printColumn',
 );
 
@@ -121,7 +121,7 @@ A print_edition should be one of the following types:
 
 has print_edition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_print_edition',
     json_ld   => 'printEdition',
 );
 
@@ -147,7 +147,7 @@ A print_page should be one of the following types:
 
 has print_page => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_print_page',
     json_ld   => 'printPage',
 );
 
@@ -172,7 +172,7 @@ A print_section should be one of the following types:
 
 has print_section => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_print_section',
     json_ld   => 'printSection',
 );
 

--- a/lib/SemanticWeb/Schema/NewsMediaOrganization.pm
+++ b/lib/SemanticWeb/Schema/NewsMediaOrganization.pm
@@ -60,7 +60,7 @@ A actionable_feedback_policy should be one of the following types:
 
 has actionable_feedback_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actionable_feedback_policy',
     json_ld   => 'actionableFeedbackPolicy',
 );
 
@@ -95,7 +95,7 @@ A corrections_policy should be one of the following types:
 
 has corrections_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_corrections_policy',
     json_ld   => 'correctionsPolicy',
 );
 
@@ -132,7 +132,7 @@ A diversity_policy should be one of the following types:
 
 has diversity_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_diversity_policy',
     json_ld   => 'diversityPolicy',
 );
 
@@ -167,7 +167,7 @@ A diversity_staffing_report should be one of the following types:
 
 has diversity_staffing_report => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_diversity_staffing_report',
     json_ld   => 'diversityStaffingReport',
 );
 
@@ -205,7 +205,7 @@ A ethics_policy should be one of the following types:
 
 has ethics_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ethics_policy',
     json_ld   => 'ethicsPolicy',
 );
 
@@ -237,7 +237,7 @@ A masthead should be one of the following types:
 
 has masthead => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_masthead',
     json_ld   => 'masthead',
 );
 
@@ -270,7 +270,7 @@ A mission_coverage_priorities_policy should be one of the following types:
 
 has mission_coverage_priorities_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_mission_coverage_priorities_policy',
     json_ld   => 'missionCoveragePrioritiesPolicy',
 );
 
@@ -304,7 +304,7 @@ A no_bylines_policy should be one of the following types:
 
 has no_bylines_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_no_bylines_policy',
     json_ld   => 'noBylinesPolicy',
 );
 
@@ -344,7 +344,7 @@ A ownership_funding_info should be one of the following types:
 
 has ownership_funding_info => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ownership_funding_info',
     json_ld   => 'ownershipFundingInfo',
 );
 
@@ -379,7 +379,7 @@ A unnamed_sources_policy should be one of the following types:
 
 has unnamed_sources_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_unnamed_sources_policy',
     json_ld   => 'unnamedSourcesPolicy',
 );
 
@@ -413,7 +413,7 @@ A verification_fact_checking_policy should be one of the following types:
 
 has verification_fact_checking_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_verification_fact_checking_policy',
     json_ld   => 'verificationFactCheckingPolicy',
 );
 

--- a/lib/SemanticWeb/Schema/NutritionInformation.pm
+++ b/lib/SemanticWeb/Schema/NutritionInformation.pm
@@ -48,7 +48,7 @@ A calories should be one of the following types:
 
 has calories => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_calories',
     json_ld   => 'calories',
 );
 
@@ -72,7 +72,7 @@ A carbohydrate_content should be one of the following types:
 
 has carbohydrate_content => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_carbohydrate_content',
     json_ld   => 'carbohydrateContent',
 );
 
@@ -96,7 +96,7 @@ A cholesterol_content should be one of the following types:
 
 has cholesterol_content => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cholesterol_content',
     json_ld   => 'cholesterolContent',
 );
 
@@ -120,7 +120,7 @@ A fat_content should be one of the following types:
 
 has fat_content => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_fat_content',
     json_ld   => 'fatContent',
 );
 
@@ -144,7 +144,7 @@ A fiber_content should be one of the following types:
 
 has fiber_content => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_fiber_content',
     json_ld   => 'fiberContent',
 );
 
@@ -168,7 +168,7 @@ A protein_content should be one of the following types:
 
 has protein_content => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_protein_content',
     json_ld   => 'proteinContent',
 );
 
@@ -192,7 +192,7 @@ A saturated_fat_content should be one of the following types:
 
 has saturated_fat_content => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_saturated_fat_content',
     json_ld   => 'saturatedFatContent',
 );
 
@@ -216,7 +216,7 @@ A serving_size should be one of the following types:
 
 has serving_size => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_serving_size',
     json_ld   => 'servingSize',
 );
 
@@ -240,7 +240,7 @@ A sodium_content should be one of the following types:
 
 has sodium_content => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sodium_content',
     json_ld   => 'sodiumContent',
 );
 
@@ -264,7 +264,7 @@ A sugar_content should be one of the following types:
 
 has sugar_content => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sugar_content',
     json_ld   => 'sugarContent',
 );
 
@@ -288,7 +288,7 @@ A trans_fat_content should be one of the following types:
 
 has trans_fat_content => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_trans_fat_content',
     json_ld   => 'transFatContent',
 );
 
@@ -312,7 +312,7 @@ A unsaturated_fat_content should be one of the following types:
 
 has unsaturated_fat_content => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_unsaturated_fat_content',
     json_ld   => 'unsaturatedFatContent',
 );
 

--- a/lib/SemanticWeb/Schema/Observation.pm
+++ b/lib/SemanticWeb/Schema/Observation.pm
@@ -79,7 +79,7 @@ A margin_of_error should be one of the following types:
 
 has margin_of_error => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_margin_of_error',
     json_ld   => 'marginOfError',
 );
 
@@ -111,7 +111,7 @@ A measured_property should be one of the following types:
 
 has measured_property => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_measured_property',
     json_ld   => 'measuredProperty',
 );
 
@@ -140,7 +140,7 @@ A measured_value should be one of the following types:
 
 has measured_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_measured_value',
     json_ld   => 'measuredValue',
 );
 
@@ -169,7 +169,7 @@ A observation_date should be one of the following types:
 
 has observation_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_observation_date',
     json_ld   => 'observationDate',
 );
 
@@ -201,7 +201,7 @@ A observed_node should be one of the following types:
 
 has observed_node => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_observed_node',
     json_ld   => 'observedNode',
 );
 

--- a/lib/SemanticWeb/Schema/Occupation.pm
+++ b/lib/SemanticWeb/Schema/Occupation.pm
@@ -50,7 +50,7 @@ A education_requirements should be one of the following types:
 
 has education_requirements => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_education_requirements',
     json_ld   => 'educationRequirements',
 );
 
@@ -81,7 +81,7 @@ A estimated_salary should be one of the following types:
 
 has estimated_salary => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_estimated_salary',
     json_ld   => 'estimatedSalary',
 );
 
@@ -105,7 +105,7 @@ A experience_requirements should be one of the following types:
 
 has experience_requirements => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_experience_requirements',
     json_ld   => 'experienceRequirements',
 );
 
@@ -131,7 +131,7 @@ A occupation_location should be one of the following types:
 
 has occupation_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_occupation_location',
     json_ld   => 'occupationLocation',
 );
 
@@ -169,7 +169,7 @@ A occupational_category should be one of the following types:
 
 has occupational_category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_occupational_category',
     json_ld   => 'occupationalCategory',
 );
 
@@ -195,7 +195,7 @@ A qualifications should be one of the following types:
 
 has qualifications => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_qualifications',
     json_ld   => 'qualifications',
 );
 
@@ -219,7 +219,7 @@ A responsibilities should be one of the following types:
 
 has responsibilities => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_responsibilities',
     json_ld   => 'responsibilities',
 );
 
@@ -247,7 +247,7 @@ A skills should be one of the following types:
 
 has skills => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_skills',
     json_ld   => 'skills',
 );
 

--- a/lib/SemanticWeb/Schema/Offer.pm
+++ b/lib/SemanticWeb/Schema/Offer.pm
@@ -63,7 +63,7 @@ A accepted_payment_method should be one of the following types:
 
 has accepted_payment_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_accepted_payment_method',
     json_ld   => 'acceptedPaymentMethod',
 );
 
@@ -89,7 +89,7 @@ A add_on should be one of the following types:
 
 has add_on => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_add_on',
     json_ld   => 'addOn',
 );
 
@@ -114,7 +114,7 @@ A advance_booking_requirement should be one of the following types:
 
 has advance_booking_requirement => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_advance_booking_requirement',
     json_ld   => 'advanceBookingRequirement',
 );
 
@@ -139,7 +139,7 @@ A aggregate_rating should be one of the following types:
 
 has aggregate_rating => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_aggregate_rating',
     json_ld   => 'aggregateRating',
 );
 
@@ -169,7 +169,7 @@ A area_served should be one of the following types:
 
 has area_served => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_area_served',
     json_ld   => 'areaServed',
 );
 
@@ -194,7 +194,7 @@ A availability should be one of the following types:
 
 has availability => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_availability',
     json_ld   => 'availability',
 );
 
@@ -219,7 +219,7 @@ A availability_ends should be one of the following types:
 
 has availability_ends => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_availability_ends',
     json_ld   => 'availabilityEnds',
 );
 
@@ -244,7 +244,7 @@ A availability_starts should be one of the following types:
 
 has availability_starts => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_availability_starts',
     json_ld   => 'availabilityStarts',
 );
 
@@ -268,7 +268,7 @@ A available_at_or_from should be one of the following types:
 
 has available_at_or_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_at_or_from',
     json_ld   => 'availableAtOrFrom',
 );
 
@@ -292,7 +292,7 @@ A available_delivery_method should be one of the following types:
 
 has available_delivery_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_delivery_method',
     json_ld   => 'availableDeliveryMethod',
 );
 
@@ -318,7 +318,7 @@ A business_function should be one of the following types:
 
 has business_function => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_business_function',
     json_ld   => 'businessFunction',
 );
 
@@ -347,7 +347,7 @@ A category should be one of the following types:
 
 has category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_category',
     json_ld   => 'category',
 );
 
@@ -373,7 +373,7 @@ A delivery_lead_time should be one of the following types:
 
 has delivery_lead_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_delivery_lead_time',
     json_ld   => 'deliveryLeadTime',
 );
 
@@ -397,7 +397,7 @@ A eligible_customer_type should be one of the following types:
 
 has eligible_customer_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_eligible_customer_type',
     json_ld   => 'eligibleCustomerType',
 );
 
@@ -421,7 +421,7 @@ A eligible_duration should be one of the following types:
 
 has eligible_duration => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_eligible_duration',
     json_ld   => 'eligibleDuration',
 );
 
@@ -447,7 +447,7 @@ A eligible_quantity should be one of the following types:
 
 has eligible_quantity => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_eligible_quantity',
     json_ld   => 'eligibleQuantity',
 );
 
@@ -483,7 +483,7 @@ A eligible_region should be one of the following types:
 
 has eligible_region => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_eligible_region',
     json_ld   => 'eligibleRegion',
 );
 
@@ -510,7 +510,7 @@ A eligible_transaction_volume should be one of the following types:
 
 has eligible_transaction_volume => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_eligible_transaction_volume',
     json_ld   => 'eligibleTransactionVolume',
 );
 
@@ -559,7 +559,7 @@ A gtin should be one of the following types:
 
 has gtin => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin',
     json_ld   => 'gtin',
 );
 
@@ -592,7 +592,7 @@ A gtin12 should be one of the following types:
 
 has gtin12 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin12',
     json_ld   => 'gtin12',
 );
 
@@ -625,7 +625,7 @@ A gtin13 should be one of the following types:
 
 has gtin13 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin13',
     json_ld   => 'gtin13',
 );
 
@@ -655,7 +655,7 @@ A gtin14 should be one of the following types:
 
 has gtin14 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin14',
     json_ld   => 'gtin14',
 );
 
@@ -688,7 +688,7 @@ A gtin8 should be one of the following types:
 
 has gtin8 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin8',
     json_ld   => 'gtin8',
 );
 
@@ -713,7 +713,7 @@ A includes_object should be one of the following types:
 
 has includes_object => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_includes_object',
     json_ld   => 'includesObject',
 );
 
@@ -749,7 +749,7 @@ A ineligible_region should be one of the following types:
 
 has ineligible_region => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ineligible_region',
     json_ld   => 'ineligibleRegion',
 );
 
@@ -773,7 +773,7 @@ A inventory_level should be one of the following types:
 
 has inventory_level => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_inventory_level',
     json_ld   => 'inventoryLevel',
 );
 
@@ -799,7 +799,7 @@ A item_condition should be one of the following types:
 
 has item_condition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_item_condition',
     json_ld   => 'itemCondition',
 );
 
@@ -825,7 +825,7 @@ A item_offered should be one of the following types:
 
 has item_offered => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_item_offered',
     json_ld   => 'itemOffered',
 );
 
@@ -850,7 +850,7 @@ A mpn should be one of the following types:
 
 has mpn => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_mpn',
     json_ld   => 'mpn',
 );
 
@@ -876,7 +876,7 @@ A offered_by should be one of the following types:
 
 has offered_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_offered_by',
     json_ld   => 'offeredBy',
 );
 
@@ -927,7 +927,7 @@ A price should be one of the following types:
 
 has price => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price',
     json_ld   => 'price',
 );
 
@@ -965,7 +965,7 @@ A price_currency should be one of the following types:
 
 has price_currency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price_currency',
     json_ld   => 'priceCurrency',
 );
 
@@ -990,7 +990,7 @@ A price_specification should be one of the following types:
 
 has price_specification => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price_specification',
     json_ld   => 'priceSpecification',
 );
 
@@ -1014,7 +1014,7 @@ A price_valid_until should be one of the following types:
 
 has price_valid_until => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price_valid_until',
     json_ld   => 'priceValidUntil',
 );
 
@@ -1038,7 +1038,7 @@ A review should be one of the following types:
 
 has review => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_review',
     json_ld   => 'review',
 );
 
@@ -1062,7 +1062,7 @@ A reviews should be one of the following types:
 
 has reviews => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_reviews',
     json_ld   => 'reviews',
 );
 
@@ -1089,7 +1089,7 @@ A seller should be one of the following types:
 
 has seller => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seller',
     json_ld   => 'seller',
 );
 
@@ -1115,7 +1115,7 @@ A serial_number should be one of the following types:
 
 has serial_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_serial_number',
     json_ld   => 'serialNumber',
 );
 
@@ -1140,7 +1140,7 @@ A sku should be one of the following types:
 
 has sku => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sku',
     json_ld   => 'sku',
 );
 
@@ -1164,7 +1164,7 @@ A valid_from should be one of the following types:
 
 has valid_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_from',
     json_ld   => 'validFrom',
 );
 
@@ -1189,7 +1189,7 @@ A valid_through should be one of the following types:
 
 has valid_through => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_through',
     json_ld   => 'validThrough',
 );
 
@@ -1213,7 +1213,7 @@ A warranty should be one of the following types:
 
 has warranty => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_warranty',
     json_ld   => 'warranty',
 );
 

--- a/lib/SemanticWeb/Schema/OpeningHoursSpecification.pm
+++ b/lib/SemanticWeb/Schema/OpeningHoursSpecification.pm
@@ -60,7 +60,7 @@ A closes should be one of the following types:
 
 has closes => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_closes',
     json_ld   => 'closes',
 );
 
@@ -84,7 +84,7 @@ A day_of_week should be one of the following types:
 
 has day_of_week => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_day_of_week',
     json_ld   => 'dayOfWeek',
 );
 
@@ -108,7 +108,7 @@ A opens should be one of the following types:
 
 has opens => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_opens',
     json_ld   => 'opens',
 );
 
@@ -132,7 +132,7 @@ A valid_from should be one of the following types:
 
 has valid_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_from',
     json_ld   => 'validFrom',
 );
 
@@ -157,7 +157,7 @@ A valid_through should be one of the following types:
 
 has valid_through => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_through',
     json_ld   => 'validThrough',
 );
 

--- a/lib/SemanticWeb/Schema/Order.pm
+++ b/lib/SemanticWeb/Schema/Order.pm
@@ -51,7 +51,7 @@ A accepted_offer should be one of the following types:
 
 has accepted_offer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_accepted_offer',
     json_ld   => 'acceptedOffer',
 );
 
@@ -75,7 +75,7 @@ A billing_address should be one of the following types:
 
 has billing_address => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_billing_address',
     json_ld   => 'billingAddress',
 );
 
@@ -104,7 +104,7 @@ A broker should be one of the following types:
 
 has broker => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broker',
     json_ld   => 'broker',
 );
 
@@ -128,7 +128,7 @@ A confirmation_number should be one of the following types:
 
 has confirmation_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_confirmation_number',
     json_ld   => 'confirmationNumber',
 );
 
@@ -154,7 +154,7 @@ A customer should be one of the following types:
 
 has customer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_customer',
     json_ld   => 'customer',
 );
 
@@ -180,7 +180,7 @@ A discount should be one of the following types:
 
 has discount => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_discount',
     json_ld   => 'discount',
 );
 
@@ -204,7 +204,7 @@ A discount_code should be one of the following types:
 
 has discount_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_discount_code',
     json_ld   => 'discountCode',
 );
 
@@ -239,7 +239,7 @@ A discount_currency should be one of the following types:
 
 has discount_currency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_discount_currency',
     json_ld   => 'discountCurrency',
 );
 
@@ -263,7 +263,7 @@ A is_gift should be one of the following types:
 
 has is_gift => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_gift',
     json_ld   => 'isGift',
 );
 
@@ -289,7 +289,7 @@ A merchant should be one of the following types:
 
 has merchant => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_merchant',
     json_ld   => 'merchant',
 );
 
@@ -313,7 +313,7 @@ A order_date should be one of the following types:
 
 has order_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_order_date',
     json_ld   => 'orderDate',
 );
 
@@ -337,7 +337,7 @@ A order_delivery should be one of the following types:
 
 has order_delivery => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_order_delivery',
     json_ld   => 'orderDelivery',
 );
 
@@ -361,7 +361,7 @@ A order_number should be one of the following types:
 
 has order_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_order_number',
     json_ld   => 'orderNumber',
 );
 
@@ -385,7 +385,7 @@ A order_status should be one of the following types:
 
 has order_status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_order_status',
     json_ld   => 'orderStatus',
 );
 
@@ -413,7 +413,7 @@ A ordered_item should be one of the following types:
 
 has ordered_item => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ordered_item',
     json_ld   => 'orderedItem',
 );
 
@@ -437,7 +437,7 @@ A part_of_invoice should be one of the following types:
 
 has part_of_invoice => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_part_of_invoice',
     json_ld   => 'partOfInvoice',
 );
 
@@ -461,7 +461,7 @@ A payment_due should be one of the following types:
 
 has payment_due => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_payment_due',
     json_ld   => 'paymentDue',
 );
 
@@ -485,7 +485,7 @@ A payment_due_date should be one of the following types:
 
 has payment_due_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_payment_due_date',
     json_ld   => 'paymentDueDate',
 );
 
@@ -509,7 +509,7 @@ A payment_method should be one of the following types:
 
 has payment_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_payment_method',
     json_ld   => 'paymentMethod',
 );
 
@@ -534,7 +534,7 @@ A payment_method_id should be one of the following types:
 
 has payment_method_id => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_payment_method_id',
     json_ld   => 'paymentMethodId',
 );
 
@@ -558,7 +558,7 @@ A payment_url should be one of the following types:
 
 has payment_url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_payment_url',
     json_ld   => 'paymentUrl',
 );
 
@@ -585,7 +585,7 @@ A seller should be one of the following types:
 
 has seller => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seller',
     json_ld   => 'seller',
 );
 

--- a/lib/SemanticWeb/Schema/OrderAction.pm
+++ b/lib/SemanticWeb/Schema/OrderAction.pm
@@ -48,7 +48,7 @@ A delivery_method should be one of the following types:
 
 has delivery_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_delivery_method',
     json_ld   => 'deliveryMethod',
 );
 

--- a/lib/SemanticWeb/Schema/OrderItem.pm
+++ b/lib/SemanticWeb/Schema/OrderItem.pm
@@ -49,7 +49,7 @@ A order_delivery should be one of the following types:
 
 has order_delivery => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_order_delivery',
     json_ld   => 'orderDelivery',
 );
 
@@ -73,7 +73,7 @@ A order_item_number should be one of the following types:
 
 has order_item_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_order_item_number',
     json_ld   => 'orderItemNumber',
 );
 
@@ -97,7 +97,7 @@ A order_item_status should be one of the following types:
 
 has order_item_status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_order_item_status',
     json_ld   => 'orderItemStatus',
 );
 
@@ -122,7 +122,7 @@ A order_quantity should be one of the following types:
 
 has order_quantity => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_order_quantity',
     json_ld   => 'orderQuantity',
 );
 
@@ -150,7 +150,7 @@ A ordered_item should be one of the following types:
 
 has ordered_item => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ordered_item',
     json_ld   => 'orderedItem',
 );
 

--- a/lib/SemanticWeb/Schema/Organization.pm
+++ b/lib/SemanticWeb/Schema/Organization.pm
@@ -60,7 +60,7 @@ A actionable_feedback_policy should be one of the following types:
 
 has actionable_feedback_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actionable_feedback_policy',
     json_ld   => 'actionableFeedbackPolicy',
 );
 
@@ -86,7 +86,7 @@ A address should be one of the following types:
 
 has address => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_address',
     json_ld   => 'address',
 );
 
@@ -111,7 +111,7 @@ A aggregate_rating should be one of the following types:
 
 has aggregate_rating => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_aggregate_rating',
     json_ld   => 'aggregateRating',
 );
 
@@ -135,7 +135,7 @@ A alumni should be one of the following types:
 
 has alumni => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_alumni',
     json_ld   => 'alumni',
 );
 
@@ -165,7 +165,7 @@ A area_served should be one of the following types:
 
 has area_served => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_area_served',
     json_ld   => 'areaServed',
 );
 
@@ -189,7 +189,7 @@ A award should be one of the following types:
 
 has award => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_award',
     json_ld   => 'award',
 );
 
@@ -213,7 +213,7 @@ A awards should be one of the following types:
 
 has awards => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_awards',
     json_ld   => 'awards',
 );
 
@@ -240,7 +240,7 @@ A brand should be one of the following types:
 
 has brand => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_brand',
     json_ld   => 'brand',
 );
 
@@ -264,7 +264,7 @@ A contact_point should be one of the following types:
 
 has contact_point => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contact_point',
     json_ld   => 'contactPoint',
 );
 
@@ -288,7 +288,7 @@ A contact_points should be one of the following types:
 
 has contact_points => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contact_points',
     json_ld   => 'contactPoints',
 );
 
@@ -323,7 +323,7 @@ A corrections_policy should be one of the following types:
 
 has corrections_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_corrections_policy',
     json_ld   => 'correctionsPolicy',
 );
 
@@ -350,7 +350,7 @@ A department should be one of the following types:
 
 has department => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_department',
     json_ld   => 'department',
 );
 
@@ -374,7 +374,7 @@ A dissolution_date should be one of the following types:
 
 has dissolution_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_dissolution_date',
     json_ld   => 'dissolutionDate',
 );
 
@@ -411,7 +411,7 @@ A diversity_policy should be one of the following types:
 
 has diversity_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_diversity_policy',
     json_ld   => 'diversityPolicy',
 );
 
@@ -446,7 +446,7 @@ A diversity_staffing_report should be one of the following types:
 
 has diversity_staffing_report => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_diversity_staffing_report',
     json_ld   => 'diversityStaffingReport',
 );
 
@@ -471,7 +471,7 @@ A duns should be one of the following types:
 
 has duns => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_duns',
     json_ld   => 'duns',
 );
 
@@ -495,7 +495,7 @@ A email should be one of the following types:
 
 has email => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_email',
     json_ld   => 'email',
 );
 
@@ -519,7 +519,7 @@ A employee should be one of the following types:
 
 has employee => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_employee',
     json_ld   => 'employee',
 );
 
@@ -543,7 +543,7 @@ A employees should be one of the following types:
 
 has employees => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_employees',
     json_ld   => 'employees',
 );
 
@@ -581,7 +581,7 @@ A ethics_policy should be one of the following types:
 
 has ethics_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ethics_policy',
     json_ld   => 'ethicsPolicy',
 );
 
@@ -605,7 +605,7 @@ A event should be one of the following types:
 
 has event => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_event',
     json_ld   => 'event',
 );
 
@@ -629,7 +629,7 @@ A events should be one of the following types:
 
 has events => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_events',
     json_ld   => 'events',
 );
 
@@ -653,7 +653,7 @@ A fax_number should be one of the following types:
 
 has fax_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_fax_number',
     json_ld   => 'faxNumber',
 );
 
@@ -677,7 +677,7 @@ A founder should be one of the following types:
 
 has founder => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_founder',
     json_ld   => 'founder',
 );
 
@@ -701,7 +701,7 @@ A founders should be one of the following types:
 
 has founders => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_founders',
     json_ld   => 'founders',
 );
 
@@ -725,7 +725,7 @@ A founding_date should be one of the following types:
 
 has founding_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_founding_date',
     json_ld   => 'foundingDate',
 );
 
@@ -749,7 +749,7 @@ A founding_location should be one of the following types:
 
 has founding_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_founding_location',
     json_ld   => 'foundingLocation',
 );
 
@@ -776,7 +776,7 @@ A funder should be one of the following types:
 
 has funder => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_funder',
     json_ld   => 'funder',
 );
 
@@ -807,7 +807,7 @@ A global_location_number should be one of the following types:
 
 has global_location_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_global_location_number',
     json_ld   => 'globalLocationNumber',
 );
 
@@ -831,7 +831,7 @@ A has_credential should be one of the following types:
 
 has has_credential => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_credential',
     json_ld   => 'hasCredential',
 );
 
@@ -856,7 +856,7 @@ A has_offer_catalog should be one of the following types:
 
 has has_offer_catalog => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_offer_catalog',
     json_ld   => 'hasOfferCatalog',
 );
 
@@ -880,7 +880,7 @@ A has_pos should be one of the following types:
 
 has has_pos => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_pos',
     json_ld   => 'hasPOS',
 );
 
@@ -904,7 +904,7 @@ A has_product_return_policy should be one of the following types:
 
 has has_product_return_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_product_return_policy',
     json_ld   => 'hasProductReturnPolicy',
 );
 
@@ -930,7 +930,7 @@ A isic_v4 should be one of the following types:
 
 has isic_v4 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_isic_v4',
     json_ld   => 'isicV4',
 );
 
@@ -966,7 +966,7 @@ A knows_about should be one of the following types:
 
 has knows_about => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_knows_about',
     json_ld   => 'knowsAbout',
 );
 
@@ -1001,7 +1001,7 @@ A knows_language should be one of the following types:
 
 has knows_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_knows_language',
     json_ld   => 'knowsLanguage',
 );
 
@@ -1025,7 +1025,7 @@ A legal_name should be one of the following types:
 
 has legal_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_legal_name',
     json_ld   => 'legalName',
 );
 
@@ -1050,7 +1050,7 @@ A lei_code should be one of the following types:
 
 has lei_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_lei_code',
     json_ld   => 'leiCode',
 );
 
@@ -1079,7 +1079,7 @@ A location should be one of the following types:
 
 has location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_location',
     json_ld   => 'location',
 );
 
@@ -1105,7 +1105,7 @@ A logo should be one of the following types:
 
 has logo => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_logo',
     json_ld   => 'logo',
 );
 
@@ -1129,7 +1129,7 @@ A makes_offer should be one of the following types:
 
 has makes_offer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_makes_offer',
     json_ld   => 'makesOffer',
 );
 
@@ -1156,7 +1156,7 @@ A member should be one of the following types:
 
 has member => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_member',
     json_ld   => 'member',
 );
 
@@ -1183,7 +1183,7 @@ A member_of should be one of the following types:
 
 has member_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_member_of',
     json_ld   => 'memberOf',
 );
 
@@ -1209,7 +1209,7 @@ A members should be one of the following types:
 
 has members => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_members',
     json_ld   => 'members',
 );
 
@@ -1234,7 +1234,7 @@ A naics should be one of the following types:
 
 has naics => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_naics',
     json_ld   => 'naics',
 );
 
@@ -1258,7 +1258,7 @@ A number_of_employees should be one of the following types:
 
 has number_of_employees => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_employees',
     json_ld   => 'numberOfEmployees',
 );
 
@@ -1298,7 +1298,7 @@ A ownership_funding_info should be one of the following types:
 
 has ownership_funding_info => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ownership_funding_info',
     json_ld   => 'ownershipFundingInfo',
 );
 
@@ -1324,7 +1324,7 @@ A owns should be one of the following types:
 
 has owns => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_owns',
     json_ld   => 'owns',
 );
 
@@ -1353,7 +1353,7 @@ A parent_organization should be one of the following types:
 
 has parent_organization => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_parent_organization',
     json_ld   => 'parentOrganization',
 );
 
@@ -1398,7 +1398,7 @@ A publishing_principles should be one of the following types:
 
 has publishing_principles => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_publishing_principles',
     json_ld   => 'publishingPrinciples',
 );
 
@@ -1422,7 +1422,7 @@ A review should be one of the following types:
 
 has review => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_review',
     json_ld   => 'review',
 );
 
@@ -1446,7 +1446,7 @@ A reviews should be one of the following types:
 
 has reviews => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_reviews',
     json_ld   => 'reviews',
 );
 
@@ -1471,7 +1471,7 @@ A seeks should be one of the following types:
 
 has seeks => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seeks',
     json_ld   => 'seeks',
 );
 
@@ -1499,7 +1499,7 @@ A service_area should be one of the following types:
 
 has service_area => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_service_area',
     json_ld   => 'serviceArea',
 );
 
@@ -1523,7 +1523,7 @@ A slogan should be one of the following types:
 
 has slogan => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_slogan',
     json_ld   => 'slogan',
 );
 
@@ -1551,7 +1551,7 @@ A sponsor should be one of the following types:
 
 has sponsor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sponsor',
     json_ld   => 'sponsor',
 );
 
@@ -1577,7 +1577,7 @@ A sub_organization should be one of the following types:
 
 has sub_organization => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sub_organization',
     json_ld   => 'subOrganization',
 );
 
@@ -1602,7 +1602,7 @@ A tax_id should be one of the following types:
 
 has tax_id => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_tax_id',
     json_ld   => 'taxID',
 );
 
@@ -1626,7 +1626,7 @@ A telephone should be one of the following types:
 
 has telephone => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_telephone',
     json_ld   => 'telephone',
 );
 
@@ -1661,7 +1661,7 @@ A unnamed_sources_policy should be one of the following types:
 
 has unnamed_sources_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_unnamed_sources_policy',
     json_ld   => 'unnamedSourcesPolicy',
 );
 
@@ -1685,7 +1685,7 @@ A vat_id should be one of the following types:
 
 has vat_id => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_vat_id',
     json_ld   => 'vatID',
 );
 

--- a/lib/SemanticWeb/Schema/OrganizationRole.pm
+++ b/lib/SemanticWeb/Schema/OrganizationRole.pm
@@ -49,7 +49,7 @@ A numbered_position should be one of the following types:
 
 has numbered_position => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_numbered_position',
     json_ld   => 'numberedPosition',
 );
 

--- a/lib/SemanticWeb/Schema/OwnershipInfo.pm
+++ b/lib/SemanticWeb/Schema/OwnershipInfo.pm
@@ -51,7 +51,7 @@ A acquired_from should be one of the following types:
 
 has acquired_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_acquired_from',
     json_ld   => 'acquiredFrom',
 );
 
@@ -75,7 +75,7 @@ A owned_from should be one of the following types:
 
 has owned_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_owned_from',
     json_ld   => 'ownedFrom',
 );
 
@@ -99,7 +99,7 @@ A owned_through should be one of the following types:
 
 has owned_through => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_owned_through',
     json_ld   => 'ownedThrough',
 );
 
@@ -125,7 +125,7 @@ A type_of_good should be one of the following types:
 
 has type_of_good => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_type_of_good',
     json_ld   => 'typeOfGood',
 );
 

--- a/lib/SemanticWeb/Schema/ParcelDelivery.pm
+++ b/lib/SemanticWeb/Schema/ParcelDelivery.pm
@@ -50,7 +50,7 @@ A carrier should be one of the following types:
 
 has carrier => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_carrier',
     json_ld   => 'carrier',
 );
 
@@ -74,7 +74,7 @@ A delivery_address should be one of the following types:
 
 has delivery_address => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_delivery_address',
     json_ld   => 'deliveryAddress',
 );
 
@@ -99,7 +99,7 @@ A delivery_status should be one of the following types:
 
 has delivery_status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_delivery_status',
     json_ld   => 'deliveryStatus',
 );
 
@@ -123,7 +123,7 @@ A expected_arrival_from should be one of the following types:
 
 has expected_arrival_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_expected_arrival_from',
     json_ld   => 'expectedArrivalFrom',
 );
 
@@ -147,7 +147,7 @@ A expected_arrival_until should be one of the following types:
 
 has expected_arrival_until => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_expected_arrival_until',
     json_ld   => 'expectedArrivalUntil',
 );
 
@@ -171,7 +171,7 @@ A has_delivery_method should be one of the following types:
 
 has has_delivery_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_delivery_method',
     json_ld   => 'hasDeliveryMethod',
 );
 
@@ -195,7 +195,7 @@ A item_shipped should be one of the following types:
 
 has item_shipped => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_item_shipped',
     json_ld   => 'itemShipped',
 );
 
@@ -219,7 +219,7 @@ A origin_address should be one of the following types:
 
 has origin_address => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_origin_address',
     json_ld   => 'originAddress',
 );
 
@@ -243,7 +243,7 @@ A part_of_order should be one of the following types:
 
 has part_of_order => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_part_of_order',
     json_ld   => 'partOfOrder',
 );
 
@@ -271,7 +271,7 @@ A provider should be one of the following types:
 
 has provider => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_provider',
     json_ld   => 'provider',
 );
 
@@ -295,7 +295,7 @@ A tracking_number should be one of the following types:
 
 has tracking_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_tracking_number',
     json_ld   => 'trackingNumber',
 );
 
@@ -319,7 +319,7 @@ A tracking_url should be one of the following types:
 
 has tracking_url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_tracking_url',
     json_ld   => 'trackingUrl',
 );
 

--- a/lib/SemanticWeb/Schema/ParentAudience.pm
+++ b/lib/SemanticWeb/Schema/ParentAudience.pm
@@ -49,7 +49,7 @@ A child_max_age should be one of the following types:
 
 has child_max_age => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_child_max_age',
     json_ld   => 'childMaxAge',
 );
 
@@ -73,7 +73,7 @@ A child_min_age should be one of the following types:
 
 has child_min_age => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_child_min_age',
     json_ld   => 'childMinAge',
 );
 

--- a/lib/SemanticWeb/Schema/PathologyTest.pm
+++ b/lib/SemanticWeb/Schema/PathologyTest.pm
@@ -49,7 +49,7 @@ A tissue_sample should be one of the following types:
 
 has tissue_sample => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_tissue_sample',
     json_ld   => 'tissueSample',
 );
 

--- a/lib/SemanticWeb/Schema/Patient.pm
+++ b/lib/SemanticWeb/Schema/Patient.pm
@@ -49,7 +49,7 @@ A diagnosis should be one of the following types:
 
 has diagnosis => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_diagnosis',
     json_ld   => 'diagnosis',
 );
 
@@ -73,7 +73,7 @@ A drug should be one of the following types:
 
 has drug => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_drug',
     json_ld   => 'drug',
 );
 
@@ -98,7 +98,7 @@ A health_condition should be one of the following types:
 
 has health_condition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_condition',
     json_ld   => 'healthCondition',
 );
 

--- a/lib/SemanticWeb/Schema/PayAction.pm
+++ b/lib/SemanticWeb/Schema/PayAction.pm
@@ -50,7 +50,7 @@ A purpose should be one of the following types:
 
 has purpose => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_purpose',
     json_ld   => 'purpose',
 );
 
@@ -81,7 +81,7 @@ A recipient should be one of the following types:
 
 has recipient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipient',
     json_ld   => 'recipient',
 );
 

--- a/lib/SemanticWeb/Schema/PaymentCard.pm
+++ b/lib/SemanticWeb/Schema/PaymentCard.pm
@@ -52,7 +52,7 @@ A cash_back should be one of the following types:
 
 has cash_back => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cash_back',
     json_ld   => 'cashBack',
 );
 
@@ -77,7 +77,7 @@ A contactless_payment should be one of the following types:
 
 has contactless_payment => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contactless_payment',
     json_ld   => 'contactlessPayment',
 );
 
@@ -102,7 +102,7 @@ A floor_limit should be one of the following types:
 
 has floor_limit => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_floor_limit',
     json_ld   => 'floorLimit',
 );
 

--- a/lib/SemanticWeb/Schema/PaymentChargeSpecification.pm
+++ b/lib/SemanticWeb/Schema/PaymentChargeSpecification.pm
@@ -49,7 +49,7 @@ A applies_to_delivery_method should be one of the following types:
 
 has applies_to_delivery_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_applies_to_delivery_method',
     json_ld   => 'appliesToDeliveryMethod',
 );
 
@@ -73,7 +73,7 @@ A applies_to_payment_method should be one of the following types:
 
 has applies_to_payment_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_applies_to_payment_method',
     json_ld   => 'appliesToPaymentMethod',
 );
 

--- a/lib/SemanticWeb/Schema/PeopleAudience.pm
+++ b/lib/SemanticWeb/Schema/PeopleAudience.pm
@@ -50,7 +50,7 @@ A health_condition should be one of the following types:
 
 has health_condition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_health_condition',
     json_ld   => 'healthCondition',
 );
 
@@ -74,7 +74,7 @@ A required_gender should be one of the following types:
 
 has required_gender => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_required_gender',
     json_ld   => 'requiredGender',
 );
 
@@ -98,7 +98,7 @@ A required_max_age should be one of the following types:
 
 has required_max_age => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_required_max_age',
     json_ld   => 'requiredMaxAge',
 );
 
@@ -122,7 +122,7 @@ A required_min_age should be one of the following types:
 
 has required_min_age => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_required_min_age',
     json_ld   => 'requiredMinAge',
 );
 
@@ -146,7 +146,7 @@ A suggested_gender should be one of the following types:
 
 has suggested_gender => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_suggested_gender',
     json_ld   => 'suggestedGender',
 );
 
@@ -170,7 +170,7 @@ A suggested_max_age should be one of the following types:
 
 has suggested_max_age => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_suggested_max_age',
     json_ld   => 'suggestedMaxAge',
 );
 
@@ -194,7 +194,7 @@ A suggested_min_age should be one of the following types:
 
 has suggested_min_age => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_suggested_min_age',
     json_ld   => 'suggestedMinAge',
 );
 

--- a/lib/SemanticWeb/Schema/PerformAction.pm
+++ b/lib/SemanticWeb/Schema/PerformAction.pm
@@ -49,7 +49,7 @@ A entertainment_business should be one of the following types:
 
 has entertainment_business => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_entertainment_business',
     json_ld   => 'entertainmentBusiness',
 );
 

--- a/lib/SemanticWeb/Schema/PerformanceRole.pm
+++ b/lib/SemanticWeb/Schema/PerformanceRole.pm
@@ -50,7 +50,7 @@ A character_name should be one of the following types:
 
 has character_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_character_name',
     json_ld   => 'characterName',
 );
 

--- a/lib/SemanticWeb/Schema/Permit.pm
+++ b/lib/SemanticWeb/Schema/Permit.pm
@@ -48,7 +48,7 @@ A issued_by should be one of the following types:
 
 has issued_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_issued_by',
     json_ld   => 'issuedBy',
 );
 
@@ -72,7 +72,7 @@ A issued_through should be one of the following types:
 
 has issued_through => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_issued_through',
     json_ld   => 'issuedThrough',
 );
 
@@ -96,7 +96,7 @@ A permit_audience should be one of the following types:
 
 has permit_audience => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_permit_audience',
     json_ld   => 'permitAudience',
 );
 
@@ -120,7 +120,7 @@ A valid_for should be one of the following types:
 
 has valid_for => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_for',
     json_ld   => 'validFor',
 );
 
@@ -144,7 +144,7 @@ A valid_from should be one of the following types:
 
 has valid_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_from',
     json_ld   => 'validFrom',
 );
 
@@ -168,7 +168,7 @@ A valid_in should be one of the following types:
 
 has valid_in => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_in',
     json_ld   => 'validIn',
 );
 
@@ -192,7 +192,7 @@ A valid_until should be one of the following types:
 
 has valid_until => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_until',
     json_ld   => 'validUntil',
 );
 

--- a/lib/SemanticWeb/Schema/Person.pm
+++ b/lib/SemanticWeb/Schema/Person.pm
@@ -48,7 +48,7 @@ A additional_name should be one of the following types:
 
 has additional_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_additional_name',
     json_ld   => 'additionalName',
 );
 
@@ -74,7 +74,7 @@ A address should be one of the following types:
 
 has address => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_address',
     json_ld   => 'address',
 );
 
@@ -99,7 +99,7 @@ A affiliation should be one of the following types:
 
 has affiliation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_affiliation',
     json_ld   => 'affiliation',
 );
 
@@ -125,7 +125,7 @@ A alumni_of should be one of the following types:
 
 has alumni_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_alumni_of',
     json_ld   => 'alumniOf',
 );
 
@@ -149,7 +149,7 @@ A award should be one of the following types:
 
 has award => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_award',
     json_ld   => 'award',
 );
 
@@ -173,7 +173,7 @@ A awards should be one of the following types:
 
 has awards => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_awards',
     json_ld   => 'awards',
 );
 
@@ -197,7 +197,7 @@ A birth_date should be one of the following types:
 
 has birth_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_birth_date',
     json_ld   => 'birthDate',
 );
 
@@ -221,7 +221,7 @@ A birth_place should be one of the following types:
 
 has birth_place => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_birth_place',
     json_ld   => 'birthPlace',
 );
 
@@ -248,7 +248,7 @@ A brand should be one of the following types:
 
 has brand => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_brand',
     json_ld   => 'brand',
 );
 
@@ -278,7 +278,7 @@ A call_sign should be one of the following types:
 
 has call_sign => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_call_sign',
     json_ld   => 'callSign',
 );
 
@@ -302,7 +302,7 @@ A children should be one of the following types:
 
 has children => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_children',
     json_ld   => 'children',
 );
 
@@ -328,7 +328,7 @@ A colleague should be one of the following types:
 
 has colleague => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_colleague',
     json_ld   => 'colleague',
 );
 
@@ -352,7 +352,7 @@ A colleagues should be one of the following types:
 
 has colleagues => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_colleagues',
     json_ld   => 'colleagues',
 );
 
@@ -376,7 +376,7 @@ A contact_point should be one of the following types:
 
 has contact_point => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contact_point',
     json_ld   => 'contactPoint',
 );
 
@@ -400,7 +400,7 @@ A contact_points should be one of the following types:
 
 has contact_points => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contact_points',
     json_ld   => 'contactPoints',
 );
 
@@ -424,7 +424,7 @@ A death_date should be one of the following types:
 
 has death_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_death_date',
     json_ld   => 'deathDate',
 );
 
@@ -448,7 +448,7 @@ A death_place should be one of the following types:
 
 has death_place => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_death_place',
     json_ld   => 'deathPlace',
 );
 
@@ -473,7 +473,7 @@ A duns should be one of the following types:
 
 has duns => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_duns',
     json_ld   => 'duns',
 );
 
@@ -497,7 +497,7 @@ A email should be one of the following types:
 
 has email => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_email',
     json_ld   => 'email',
 );
 
@@ -522,7 +522,7 @@ A family_name should be one of the following types:
 
 has family_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_family_name',
     json_ld   => 'familyName',
 );
 
@@ -546,7 +546,7 @@ A fax_number should be one of the following types:
 
 has fax_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_fax_number',
     json_ld   => 'faxNumber',
 );
 
@@ -570,7 +570,7 @@ A follows should be one of the following types:
 
 has follows => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_follows',
     json_ld   => 'follows',
 );
 
@@ -597,7 +597,7 @@ A funder should be one of the following types:
 
 has funder => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_funder',
     json_ld   => 'funder',
 );
 
@@ -637,7 +637,7 @@ A gender should be one of the following types:
 
 has gender => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gender',
     json_ld   => 'gender',
 );
 
@@ -662,7 +662,7 @@ A given_name should be one of the following types:
 
 has given_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_given_name',
     json_ld   => 'givenName',
 );
 
@@ -693,7 +693,7 @@ A global_location_number should be one of the following types:
 
 has global_location_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_global_location_number',
     json_ld   => 'globalLocationNumber',
 );
 
@@ -717,7 +717,7 @@ A has_credential should be one of the following types:
 
 has has_credential => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_credential',
     json_ld   => 'hasCredential',
 );
 
@@ -742,7 +742,7 @@ A has_occupation should be one of the following types:
 
 has has_occupation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_occupation',
     json_ld   => 'hasOccupation',
 );
 
@@ -767,7 +767,7 @@ A has_offer_catalog should be one of the following types:
 
 has has_offer_catalog => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_offer_catalog',
     json_ld   => 'hasOfferCatalog',
 );
 
@@ -791,7 +791,7 @@ A has_pos should be one of the following types:
 
 has has_pos => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_pos',
     json_ld   => 'hasPOS',
 );
 
@@ -817,7 +817,7 @@ A height should be one of the following types:
 
 has height => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_height',
     json_ld   => 'height',
 );
 
@@ -843,7 +843,7 @@ A home_location should be one of the following types:
 
 has home_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_home_location',
     json_ld   => 'homeLocation',
 );
 
@@ -867,7 +867,7 @@ A honorific_prefix should be one of the following types:
 
 has honorific_prefix => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_honorific_prefix',
     json_ld   => 'honorificPrefix',
 );
 
@@ -891,7 +891,7 @@ A honorific_suffix should be one of the following types:
 
 has honorific_suffix => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_honorific_suffix',
     json_ld   => 'honorificSuffix',
 );
 
@@ -917,7 +917,7 @@ A isic_v4 should be one of the following types:
 
 has isic_v4 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_isic_v4',
     json_ld   => 'isicV4',
 );
 
@@ -943,7 +943,7 @@ A job_title should be one of the following types:
 
 has job_title => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_job_title',
     json_ld   => 'jobTitle',
 );
 
@@ -967,7 +967,7 @@ A knows should be one of the following types:
 
 has knows => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_knows',
     json_ld   => 'knows',
 );
 
@@ -1003,7 +1003,7 @@ A knows_about should be one of the following types:
 
 has knows_about => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_knows_about',
     json_ld   => 'knowsAbout',
 );
 
@@ -1038,7 +1038,7 @@ A knows_language should be one of the following types:
 
 has knows_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_knows_language',
     json_ld   => 'knowsLanguage',
 );
 
@@ -1062,7 +1062,7 @@ A makes_offer should be one of the following types:
 
 has makes_offer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_makes_offer',
     json_ld   => 'makesOffer',
 );
 
@@ -1089,7 +1089,7 @@ A member_of should be one of the following types:
 
 has member_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_member_of',
     json_ld   => 'memberOf',
 );
 
@@ -1114,7 +1114,7 @@ A naics should be one of the following types:
 
 has naics => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_naics',
     json_ld   => 'naics',
 );
 
@@ -1138,7 +1138,7 @@ A nationality should be one of the following types:
 
 has nationality => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_nationality',
     json_ld   => 'nationality',
 );
 
@@ -1165,7 +1165,7 @@ A net_worth should be one of the following types:
 
 has net_worth => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_net_worth',
     json_ld   => 'netWorth',
 );
 
@@ -1191,7 +1191,7 @@ A owns should be one of the following types:
 
 has owns => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_owns',
     json_ld   => 'owns',
 );
 
@@ -1215,7 +1215,7 @@ A parent should be one of the following types:
 
 has parent => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_parent',
     json_ld   => 'parent',
 );
 
@@ -1239,7 +1239,7 @@ A parents should be one of the following types:
 
 has parents => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_parents',
     json_ld   => 'parents',
 );
 
@@ -1263,7 +1263,7 @@ A performer_in should be one of the following types:
 
 has performer_in => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_performer_in',
     json_ld   => 'performerIn',
 );
 
@@ -1308,7 +1308,7 @@ A publishing_principles should be one of the following types:
 
 has publishing_principles => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_publishing_principles',
     json_ld   => 'publishingPrinciples',
 );
 
@@ -1332,7 +1332,7 @@ A related_to should be one of the following types:
 
 has related_to => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_related_to',
     json_ld   => 'relatedTo',
 );
 
@@ -1357,7 +1357,7 @@ A seeks should be one of the following types:
 
 has seeks => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seeks',
     json_ld   => 'seeks',
 );
 
@@ -1381,7 +1381,7 @@ A sibling should be one of the following types:
 
 has sibling => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sibling',
     json_ld   => 'sibling',
 );
 
@@ -1405,7 +1405,7 @@ A siblings should be one of the following types:
 
 has siblings => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_siblings',
     json_ld   => 'siblings',
 );
 
@@ -1433,7 +1433,7 @@ A sponsor should be one of the following types:
 
 has sponsor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sponsor',
     json_ld   => 'sponsor',
 );
 
@@ -1457,7 +1457,7 @@ A spouse should be one of the following types:
 
 has spouse => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_spouse',
     json_ld   => 'spouse',
 );
 
@@ -1482,7 +1482,7 @@ A tax_id should be one of the following types:
 
 has tax_id => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_tax_id',
     json_ld   => 'taxID',
 );
 
@@ -1506,7 +1506,7 @@ A telephone should be one of the following types:
 
 has telephone => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_telephone',
     json_ld   => 'telephone',
 );
 
@@ -1530,7 +1530,7 @@ A vat_id should be one of the following types:
 
 has vat_id => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_vat_id',
     json_ld   => 'vatID',
 );
 
@@ -1554,7 +1554,7 @@ A weight should be one of the following types:
 
 has weight => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_weight',
     json_ld   => 'weight',
 );
 
@@ -1580,7 +1580,7 @@ A work_location should be one of the following types:
 
 has work_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_work_location',
     json_ld   => 'workLocation',
 );
 
@@ -1604,7 +1604,7 @@ A works_for should be one of the following types:
 
 has works_for => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_works_for',
     json_ld   => 'worksFor',
 );
 

--- a/lib/SemanticWeb/Schema/PhysicalActivity.pm
+++ b/lib/SemanticWeb/Schema/PhysicalActivity.pm
@@ -56,7 +56,7 @@ A associated_anatomy should be one of the following types:
 
 has associated_anatomy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_associated_anatomy',
     json_ld   => 'associatedAnatomy',
 );
 
@@ -85,7 +85,7 @@ A category should be one of the following types:
 
 has category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_category',
     json_ld   => 'category',
 );
 
@@ -109,7 +109,7 @@ A epidemiology should be one of the following types:
 
 has epidemiology => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_epidemiology',
     json_ld   => 'epidemiology',
 );
 
@@ -134,7 +134,7 @@ A pathophysiology should be one of the following types:
 
 has pathophysiology => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pathophysiology',
     json_ld   => 'pathophysiology',
 );
 

--- a/lib/SemanticWeb/Schema/Physician.pm
+++ b/lib/SemanticWeb/Schema/Physician.pm
@@ -52,7 +52,7 @@ A available_service should be one of the following types:
 
 has available_service => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_service',
     json_ld   => 'availableService',
 );
 
@@ -76,7 +76,7 @@ A hospital_affiliation should be one of the following types:
 
 has hospital_affiliation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_hospital_affiliation',
     json_ld   => 'hospitalAffiliation',
 );
 
@@ -100,7 +100,7 @@ A medical_specialty should be one of the following types:
 
 has medical_specialty => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_medical_specialty',
     json_ld   => 'medicalSpecialty',
 );
 

--- a/lib/SemanticWeb/Schema/Place.pm
+++ b/lib/SemanticWeb/Schema/Place.pm
@@ -59,7 +59,7 @@ A additional_property should be one of the following types:
 
 has additional_property => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_additional_property',
     json_ld   => 'additionalProperty',
 );
 
@@ -85,7 +85,7 @@ A address should be one of the following types:
 
 has address => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_address',
     json_ld   => 'address',
 );
 
@@ -110,7 +110,7 @@ A aggregate_rating should be one of the following types:
 
 has aggregate_rating => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_aggregate_rating',
     json_ld   => 'aggregateRating',
 );
 
@@ -137,7 +137,7 @@ A amenity_feature should be one of the following types:
 
 has amenity_feature => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_amenity_feature',
     json_ld   => 'amenityFeature',
 );
 
@@ -169,7 +169,7 @@ A branch_code should be one of the following types:
 
 has branch_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_branch_code',
     json_ld   => 'branchCode',
 );
 
@@ -193,7 +193,7 @@ A contained_in should be one of the following types:
 
 has contained_in => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contained_in',
     json_ld   => 'containedIn',
 );
 
@@ -217,7 +217,7 @@ A contained_in_place should be one of the following types:
 
 has contained_in_place => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contained_in_place',
     json_ld   => 'containedInPlace',
 );
 
@@ -242,7 +242,7 @@ A contains_place should be one of the following types:
 
 has contains_place => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contains_place',
     json_ld   => 'containsPlace',
 );
 
@@ -266,7 +266,7 @@ A event should be one of the following types:
 
 has event => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_event',
     json_ld   => 'event',
 );
 
@@ -290,7 +290,7 @@ A events should be one of the following types:
 
 has events => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_events',
     json_ld   => 'events',
 );
 
@@ -314,7 +314,7 @@ A fax_number should be one of the following types:
 
 has fax_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_fax_number',
     json_ld   => 'faxNumber',
 );
 
@@ -340,7 +340,7 @@ A geo should be one of the following types:
 
 has geo => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo',
     json_ld   => 'geo',
 );
 
@@ -374,7 +374,7 @@ A geo_contains should be one of the following types:
 
 has geo_contains => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_contains',
     json_ld   => 'geoContains',
 );
 
@@ -406,7 +406,7 @@ A geo_covered_by should be one of the following types:
 
 has geo_covered_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_covered_by',
     json_ld   => 'geoCoveredBy',
 );
 
@@ -439,7 +439,7 @@ A geo_covers should be one of the following types:
 
 has geo_covers => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_covers',
     json_ld   => 'geoCovers',
 );
 
@@ -473,7 +473,7 @@ A geo_crosses should be one of the following types:
 
 has geo_crosses => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_crosses',
     json_ld   => 'geoCrosses',
 );
 
@@ -506,7 +506,7 @@ A geo_disjoint should be one of the following types:
 
 has geo_disjoint => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_disjoint',
     json_ld   => 'geoDisjoint',
 );
 
@@ -541,7 +541,7 @@ A geo_equals should be one of the following types:
 
 has geo_equals => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_equals',
     json_ld   => 'geoEquals',
 );
 
@@ -573,7 +573,7 @@ A geo_intersects should be one of the following types:
 
 has geo_intersects => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_intersects',
     json_ld   => 'geoIntersects',
 );
 
@@ -606,7 +606,7 @@ A geo_overlaps should be one of the following types:
 
 has geo_overlaps => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_overlaps',
     json_ld   => 'geoOverlaps',
 );
 
@@ -639,7 +639,7 @@ A geo_touches should be one of the following types:
 
 has geo_touches => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_touches',
     json_ld   => 'geoTouches',
 );
 
@@ -672,7 +672,7 @@ A geo_within should be one of the following types:
 
 has geo_within => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_geo_within',
     json_ld   => 'geoWithin',
 );
 
@@ -703,7 +703,7 @@ A global_location_number should be one of the following types:
 
 has global_location_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_global_location_number',
     json_ld   => 'globalLocationNumber',
 );
 
@@ -729,7 +729,7 @@ A has_map should be one of the following types:
 
 has has_map => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_map',
     json_ld   => 'hasMap',
 );
 
@@ -753,7 +753,7 @@ A is_accessible_for_free should be one of the following types:
 
 has is_accessible_for_free => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_accessible_for_free',
     json_ld   => 'isAccessibleForFree',
 );
 
@@ -779,7 +779,7 @@ A isic_v4 should be one of the following types:
 
 has isic_v4 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_isic_v4',
     json_ld   => 'isicV4',
 );
 
@@ -810,7 +810,7 @@ A latitude should be one of the following types:
 
 has latitude => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_latitude',
     json_ld   => 'latitude',
 );
 
@@ -836,7 +836,7 @@ A logo should be one of the following types:
 
 has logo => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_logo',
     json_ld   => 'logo',
 );
 
@@ -867,7 +867,7 @@ A longitude should be one of the following types:
 
 has longitude => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_longitude',
     json_ld   => 'longitude',
 );
 
@@ -891,7 +891,7 @@ A map should be one of the following types:
 
 has map => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_map',
     json_ld   => 'map',
 );
 
@@ -915,7 +915,7 @@ A maps should be one of the following types:
 
 has maps => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_maps',
     json_ld   => 'maps',
 );
 
@@ -939,7 +939,7 @@ A maximum_attendee_capacity should be one of the following types:
 
 has maximum_attendee_capacity => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_maximum_attendee_capacity',
     json_ld   => 'maximumAttendeeCapacity',
 );
 
@@ -963,7 +963,7 @@ A opening_hours_specification should be one of the following types:
 
 has opening_hours_specification => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_opening_hours_specification',
     json_ld   => 'openingHoursSpecification',
 );
 
@@ -989,7 +989,7 @@ A photo should be one of the following types:
 
 has photo => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_photo',
     json_ld   => 'photo',
 );
 
@@ -1015,7 +1015,7 @@ A photos should be one of the following types:
 
 has photos => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_photos',
     json_ld   => 'photos',
 );
 
@@ -1045,7 +1045,7 @@ A public_access should be one of the following types:
 
 has public_access => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_public_access',
     json_ld   => 'publicAccess',
 );
 
@@ -1069,7 +1069,7 @@ A review should be one of the following types:
 
 has review => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_review',
     json_ld   => 'review',
 );
 
@@ -1093,7 +1093,7 @@ A reviews should be one of the following types:
 
 has reviews => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_reviews',
     json_ld   => 'reviews',
 );
 
@@ -1117,7 +1117,7 @@ A slogan should be one of the following types:
 
 has slogan => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_slogan',
     json_ld   => 'slogan',
 );
 
@@ -1142,7 +1142,7 @@ A smoking_allowed should be one of the following types:
 
 has smoking_allowed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_smoking_allowed',
     json_ld   => 'smokingAllowed',
 );
 
@@ -1175,7 +1175,7 @@ A special_opening_hours_specification should be one of the following types:
 
 has special_opening_hours_specification => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_special_opening_hours_specification',
     json_ld   => 'specialOpeningHoursSpecification',
 );
 
@@ -1199,7 +1199,7 @@ A telephone should be one of the following types:
 
 has telephone => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_telephone',
     json_ld   => 'telephone',
 );
 

--- a/lib/SemanticWeb/Schema/PlanAction.pm
+++ b/lib/SemanticWeb/Schema/PlanAction.pm
@@ -49,7 +49,7 @@ A scheduled_time should be one of the following types:
 
 has scheduled_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_scheduled_time',
     json_ld   => 'scheduledTime',
 );
 

--- a/lib/SemanticWeb/Schema/PlayAction.pm
+++ b/lib/SemanticWeb/Schema/PlayAction.pm
@@ -61,7 +61,7 @@ A audience should be one of the following types:
 
 has audience => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_audience',
     json_ld   => 'audience',
 );
 
@@ -85,7 +85,7 @@ A event should be one of the following types:
 
 has event => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_event',
     json_ld   => 'event',
 );
 

--- a/lib/SemanticWeb/Schema/PodcastSeries.pm
+++ b/lib/SemanticWeb/Schema/PodcastSeries.pm
@@ -50,7 +50,7 @@ A web_feed should be one of the following types:
 
 has web_feed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_web_feed',
     json_ld   => 'webFeed',
 );
 

--- a/lib/SemanticWeb/Schema/PostalAddress.pm
+++ b/lib/SemanticWeb/Schema/PostalAddress.pm
@@ -56,7 +56,7 @@ A address_country should be one of the following types:
 
 has address_country => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_address_country',
     json_ld   => 'addressCountry',
 );
 
@@ -81,7 +81,7 @@ A address_locality should be one of the following types:
 
 has address_locality => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_address_locality',
     json_ld   => 'addressLocality',
 );
 
@@ -112,7 +112,7 @@ A address_region should be one of the following types:
 
 has address_region => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_address_region',
     json_ld   => 'addressRegion',
 );
 
@@ -136,7 +136,7 @@ A post_office_box_number should be one of the following types:
 
 has post_office_box_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_post_office_box_number',
     json_ld   => 'postOfficeBoxNumber',
 );
 
@@ -160,7 +160,7 @@ A postal_code should be one of the following types:
 
 has postal_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_postal_code',
     json_ld   => 'postalCode',
 );
 
@@ -184,7 +184,7 @@ A street_address should be one of the following types:
 
 has street_address => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_street_address',
     json_ld   => 'streetAddress',
 );
 

--- a/lib/SemanticWeb/Schema/PriceSpecification.pm
+++ b/lib/SemanticWeb/Schema/PriceSpecification.pm
@@ -58,7 +58,7 @@ A eligible_quantity should be one of the following types:
 
 has eligible_quantity => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_eligible_quantity',
     json_ld   => 'eligibleQuantity',
 );
 
@@ -85,7 +85,7 @@ A eligible_transaction_volume should be one of the following types:
 
 has eligible_transaction_volume => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_eligible_transaction_volume',
     json_ld   => 'eligibleTransactionVolume',
 );
 
@@ -109,7 +109,7 @@ A max_price should be one of the following types:
 
 has max_price => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_max_price',
     json_ld   => 'maxPrice',
 );
 
@@ -133,7 +133,7 @@ A min_price should be one of the following types:
 
 has min_price => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_min_price',
     json_ld   => 'minPrice',
 );
 
@@ -184,7 +184,7 @@ A price should be one of the following types:
 
 has price => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price',
     json_ld   => 'price',
 );
 
@@ -222,7 +222,7 @@ A price_currency should be one of the following types:
 
 has price_currency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price_currency',
     json_ld   => 'priceCurrency',
 );
 
@@ -246,7 +246,7 @@ A valid_from should be one of the following types:
 
 has valid_from => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_from',
     json_ld   => 'validFrom',
 );
 
@@ -271,7 +271,7 @@ A valid_through should be one of the following types:
 
 has valid_through => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_valid_through',
     json_ld   => 'validThrough',
 );
 
@@ -296,7 +296,7 @@ A value_added_tax_included should be one of the following types:
 
 has value_added_tax_included => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_value_added_tax_included',
     json_ld   => 'valueAddedTaxIncluded',
 );
 

--- a/lib/SemanticWeb/Schema/Product.pm
+++ b/lib/SemanticWeb/Schema/Product.pm
@@ -61,7 +61,7 @@ A additional_property should be one of the following types:
 
 has additional_property => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_additional_property',
     json_ld   => 'additionalProperty',
 );
 
@@ -86,7 +86,7 @@ A aggregate_rating should be one of the following types:
 
 has aggregate_rating => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_aggregate_rating',
     json_ld   => 'aggregateRating',
 );
 
@@ -110,7 +110,7 @@ A audience should be one of the following types:
 
 has audience => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_audience',
     json_ld   => 'audience',
 );
 
@@ -134,7 +134,7 @@ A award should be one of the following types:
 
 has award => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_award',
     json_ld   => 'award',
 );
 
@@ -158,7 +158,7 @@ A awards should be one of the following types:
 
 has awards => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_awards',
     json_ld   => 'awards',
 );
 
@@ -185,7 +185,7 @@ A brand should be one of the following types:
 
 has brand => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_brand',
     json_ld   => 'brand',
 );
 
@@ -214,7 +214,7 @@ A category should be one of the following types:
 
 has category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_category',
     json_ld   => 'category',
 );
 
@@ -238,7 +238,7 @@ A color should be one of the following types:
 
 has color => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_color',
     json_ld   => 'color',
 );
 
@@ -264,7 +264,7 @@ A depth should be one of the following types:
 
 has depth => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_depth',
     json_ld   => 'depth',
 );
 
@@ -313,7 +313,7 @@ A gtin should be one of the following types:
 
 has gtin => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin',
     json_ld   => 'gtin',
 );
 
@@ -346,7 +346,7 @@ A gtin12 should be one of the following types:
 
 has gtin12 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin12',
     json_ld   => 'gtin12',
 );
 
@@ -379,7 +379,7 @@ A gtin13 should be one of the following types:
 
 has gtin13 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin13',
     json_ld   => 'gtin13',
 );
 
@@ -409,7 +409,7 @@ A gtin14 should be one of the following types:
 
 has gtin14 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin14',
     json_ld   => 'gtin14',
 );
 
@@ -442,7 +442,7 @@ A gtin8 should be one of the following types:
 
 has gtin8 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gtin8',
     json_ld   => 'gtin8',
 );
 
@@ -466,7 +466,7 @@ A has_product_return_policy should be one of the following types:
 
 has has_product_return_policy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_product_return_policy',
     json_ld   => 'hasProductReturnPolicy',
 );
 
@@ -492,7 +492,7 @@ A height should be one of the following types:
 
 has height => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_height',
     json_ld   => 'height',
 );
 
@@ -517,7 +517,7 @@ A is_accessory_or_spare_part_for should be one of the following types:
 
 has is_accessory_or_spare_part_for => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_accessory_or_spare_part_for',
     json_ld   => 'isAccessoryOrSparePartFor',
 );
 
@@ -542,7 +542,7 @@ A is_consumable_for should be one of the following types:
 
 has is_consumable_for => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_consumable_for',
     json_ld   => 'isConsumableFor',
 );
 
@@ -568,7 +568,7 @@ A is_related_to should be one of the following types:
 
 has is_related_to => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_related_to',
     json_ld   => 'isRelatedTo',
 );
 
@@ -594,7 +594,7 @@ A is_similar_to should be one of the following types:
 
 has is_similar_to => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_similar_to',
     json_ld   => 'isSimilarTo',
 );
 
@@ -620,7 +620,7 @@ A item_condition should be one of the following types:
 
 has item_condition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_item_condition',
     json_ld   => 'itemCondition',
 );
 
@@ -646,7 +646,7 @@ A logo should be one of the following types:
 
 has logo => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_logo',
     json_ld   => 'logo',
 );
 
@@ -670,7 +670,7 @@ A manufacturer should be one of the following types:
 
 has manufacturer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_manufacturer',
     json_ld   => 'manufacturer',
 );
 
@@ -696,7 +696,7 @@ A material should be one of the following types:
 
 has material => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_material',
     json_ld   => 'material',
 );
 
@@ -725,7 +725,7 @@ A model should be one of the following types:
 
 has model => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_model',
     json_ld   => 'model',
 );
 
@@ -750,7 +750,7 @@ A mpn should be one of the following types:
 
 has mpn => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_mpn',
     json_ld   => 'mpn',
 );
 
@@ -781,7 +781,7 @@ A nsn should be one of the following types:
 
 has nsn => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_nsn',
     json_ld   => 'nsn',
 );
 
@@ -807,7 +807,7 @@ A offers should be one of the following types:
 
 has offers => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_offers',
     json_ld   => 'offers',
 );
 
@@ -836,7 +836,7 @@ A product_id should be one of the following types:
 
 has product_id => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_product_id',
     json_ld   => 'productID',
 );
 
@@ -860,7 +860,7 @@ A production_date should be one of the following types:
 
 has production_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_production_date',
     json_ld   => 'productionDate',
 );
 
@@ -884,7 +884,7 @@ A purchase_date should be one of the following types:
 
 has purchase_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_purchase_date',
     json_ld   => 'purchaseDate',
 );
 
@@ -909,7 +909,7 @@ A release_date should be one of the following types:
 
 has release_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_release_date',
     json_ld   => 'releaseDate',
 );
 
@@ -933,7 +933,7 @@ A review should be one of the following types:
 
 has review => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_review',
     json_ld   => 'review',
 );
 
@@ -957,7 +957,7 @@ A reviews should be one of the following types:
 
 has reviews => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_reviews',
     json_ld   => 'reviews',
 );
 
@@ -982,7 +982,7 @@ A sku should be one of the following types:
 
 has sku => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sku',
     json_ld   => 'sku',
 );
 
@@ -1006,7 +1006,7 @@ A slogan should be one of the following types:
 
 has slogan => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_slogan',
     json_ld   => 'slogan',
 );
 
@@ -1030,7 +1030,7 @@ A weight should be one of the following types:
 
 has weight => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_weight',
     json_ld   => 'weight',
 );
 
@@ -1056,7 +1056,7 @@ A width should be one of the following types:
 
 has width => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_width',
     json_ld   => 'width',
 );
 

--- a/lib/SemanticWeb/Schema/ProductModel.pm
+++ b/lib/SemanticWeb/Schema/ProductModel.pm
@@ -51,7 +51,7 @@ A is_variant_of should be one of the following types:
 
 has is_variant_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_variant_of',
     json_ld   => 'isVariantOf',
 );
 
@@ -76,7 +76,7 @@ A predecessor_of should be one of the following types:
 
 has predecessor_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_predecessor_of',
     json_ld   => 'predecessorOf',
 );
 
@@ -101,7 +101,7 @@ A successor_of should be one of the following types:
 
 has successor_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_successor_of',
     json_ld   => 'successorOf',
 );
 

--- a/lib/SemanticWeb/Schema/ProductReturnPolicy.pm
+++ b/lib/SemanticWeb/Schema/ProductReturnPolicy.pm
@@ -55,7 +55,7 @@ A in_store_returns_offered should be one of the following types:
 
 has in_store_returns_offered => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_in_store_returns_offered',
     json_ld   => 'inStoreReturnsOffered',
 );
 
@@ -80,7 +80,7 @@ A product_return_days should be one of the following types:
 
 has product_return_days => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_product_return_days',
     json_ld   => 'productReturnDays',
 );
 
@@ -104,7 +104,7 @@ A product_return_link should be one of the following types:
 
 has product_return_link => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_product_return_link',
     json_ld   => 'productReturnLink',
 );
 
@@ -128,7 +128,7 @@ A refund_type should be one of the following types:
 
 has refund_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_refund_type',
     json_ld   => 'refundType',
 );
 
@@ -153,7 +153,7 @@ A return_fees should be one of the following types:
 
 has return_fees => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_return_fees',
     json_ld   => 'returnFees',
 );
 
@@ -178,7 +178,7 @@ A return_policy_category should be one of the following types:
 
 has return_policy_category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_return_policy_category',
     json_ld   => 'returnPolicyCategory',
 );
 

--- a/lib/SemanticWeb/Schema/ProgramMembership.pm
+++ b/lib/SemanticWeb/Schema/ProgramMembership.pm
@@ -50,7 +50,7 @@ A hosting_organization should be one of the following types:
 
 has hosting_organization => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_hosting_organization',
     json_ld   => 'hostingOrganization',
 );
 
@@ -77,7 +77,7 @@ A member should be one of the following types:
 
 has member => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_member',
     json_ld   => 'member',
 );
 
@@ -103,7 +103,7 @@ A members should be one of the following types:
 
 has members => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_members',
     json_ld   => 'members',
 );
 
@@ -127,7 +127,7 @@ A membership_number should be one of the following types:
 
 has membership_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_membership_number',
     json_ld   => 'membershipNumber',
 );
 
@@ -155,7 +155,7 @@ A membership_points_earned should be one of the following types:
 
 has membership_points_earned => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_membership_points_earned',
     json_ld   => 'membershipPointsEarned',
 );
 
@@ -179,7 +179,7 @@ A program_name should be one of the following types:
 
 has program_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_program_name',
     json_ld   => 'programName',
 );
 

--- a/lib/SemanticWeb/Schema/Property.pm
+++ b/lib/SemanticWeb/Schema/Property.pm
@@ -50,7 +50,7 @@ A domain_includes should be one of the following types:
 
 has domain_includes => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_domain_includes',
     json_ld   => 'domainIncludes',
 );
 
@@ -78,7 +78,7 @@ A inverse_of should be one of the following types:
 
 has inverse_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_inverse_of',
     json_ld   => 'inverseOf',
 );
 
@@ -103,7 +103,7 @@ A range_includes should be one of the following types:
 
 has range_includes => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_range_includes',
     json_ld   => 'rangeIncludes',
 );
 
@@ -132,7 +132,7 @@ A superseded_by should be one of the following types:
 
 has superseded_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_superseded_by',
     json_ld   => 'supersededBy',
 );
 

--- a/lib/SemanticWeb/Schema/PropertyValue.pm
+++ b/lib/SemanticWeb/Schema/PropertyValue.pm
@@ -58,7 +58,7 @@ A max_value should be one of the following types:
 
 has max_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_max_value',
     json_ld   => 'maxValue',
 );
 
@@ -113,7 +113,7 @@ A measurement_technique should be one of the following types:
 
 has measurement_technique => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_measurement_technique',
     json_ld   => 'measurementTechnique',
 );
 
@@ -137,7 +137,7 @@ A min_value should be one of the following types:
 
 has min_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_min_value',
     json_ld   => 'minValue',
 );
 
@@ -169,7 +169,7 @@ A property_id should be one of the following types:
 
 has property_id => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_property_id',
     json_ld   => 'propertyID',
 );
 
@@ -195,7 +195,7 @@ A unit_code should be one of the following types:
 
 has unit_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_unit_code',
     json_ld   => 'unitCode',
 );
 
@@ -224,7 +224,7 @@ A unit_text should be one of the following types:
 
 has unit_text => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_unit_text',
     json_ld   => 'unitText',
 );
 
@@ -269,7 +269,7 @@ A value should be one of the following types:
 
 has value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_value',
     json_ld   => 'value',
 );
 
@@ -302,7 +302,7 @@ A value_reference should be one of the following types:
 
 has value_reference => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_value_reference',
     json_ld   => 'valueReference',
 );
 

--- a/lib/SemanticWeb/Schema/PropertyValueSpecification.pm
+++ b/lib/SemanticWeb/Schema/PropertyValueSpecification.pm
@@ -52,7 +52,7 @@ A default_value should be one of the following types:
 
 has default_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_default_value',
     json_ld   => 'defaultValue',
 );
 
@@ -76,7 +76,7 @@ A max_value should be one of the following types:
 
 has max_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_max_value',
     json_ld   => 'maxValue',
 );
 
@@ -100,7 +100,7 @@ A min_value should be one of the following types:
 
 has min_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_min_value',
     json_ld   => 'minValue',
 );
 
@@ -124,7 +124,7 @@ A multiple_values should be one of the following types:
 
 has multiple_values => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_multiple_values',
     json_ld   => 'multipleValues',
 );
 
@@ -150,7 +150,7 @@ A readonly_value should be one of the following types:
 
 has readonly_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_readonly_value',
     json_ld   => 'readonlyValue',
 );
 
@@ -175,7 +175,7 @@ A step_value should be one of the following types:
 
 has step_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_step_value',
     json_ld   => 'stepValue',
 );
 
@@ -199,7 +199,7 @@ A value_max_length should be one of the following types:
 
 has value_max_length => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_value_max_length',
     json_ld   => 'valueMaxLength',
 );
 
@@ -224,7 +224,7 @@ A value_min_length should be one of the following types:
 
 has value_min_length => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_value_min_length',
     json_ld   => 'valueMinLength',
 );
 
@@ -249,7 +249,7 @@ A value_name should be one of the following types:
 
 has value_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_value_name',
     json_ld   => 'valueName',
 );
 
@@ -274,7 +274,7 @@ A value_pattern should be one of the following types:
 
 has value_pattern => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_value_pattern',
     json_ld   => 'valuePattern',
 );
 
@@ -299,7 +299,7 @@ A value_required should be one of the following types:
 
 has value_required => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_value_required',
     json_ld   => 'valueRequired',
 );
 

--- a/lib/SemanticWeb/Schema/PublicationEvent.pm
+++ b/lib/SemanticWeb/Schema/PublicationEvent.pm
@@ -50,7 +50,7 @@ A free should be one of the following types:
 
 has free => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_free',
     json_ld   => 'free',
 );
 
@@ -74,7 +74,7 @@ A is_accessible_for_free should be one of the following types:
 
 has is_accessible_for_free => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_accessible_for_free',
     json_ld   => 'isAccessibleForFree',
 );
 
@@ -100,7 +100,7 @@ A published_by should be one of the following types:
 
 has published_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_published_by',
     json_ld   => 'publishedBy',
 );
 
@@ -124,7 +124,7 @@ A published_on should be one of the following types:
 
 has published_on => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_published_on',
     json_ld   => 'publishedOn',
 );
 

--- a/lib/SemanticWeb/Schema/PublicationIssue.pm
+++ b/lib/SemanticWeb/Schema/PublicationIssue.pm
@@ -58,7 +58,7 @@ A issue_number should be one of the following types:
 
 has issue_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_issue_number',
     json_ld   => 'issueNumber',
 );
 
@@ -84,7 +84,7 @@ A page_end should be one of the following types:
 
 has page_end => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_page_end',
     json_ld   => 'pageEnd',
 );
 
@@ -110,7 +110,7 @@ A page_start should be one of the following types:
 
 has page_start => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_page_start',
     json_ld   => 'pageStart',
 );
 
@@ -135,7 +135,7 @@ A pagination should be one of the following types:
 
 has pagination => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pagination',
     json_ld   => 'pagination',
 );
 

--- a/lib/SemanticWeb/Schema/PublicationVolume.pm
+++ b/lib/SemanticWeb/Schema/PublicationVolume.pm
@@ -58,7 +58,7 @@ A page_end should be one of the following types:
 
 has page_end => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_page_end',
     json_ld   => 'pageEnd',
 );
 
@@ -84,7 +84,7 @@ A page_start should be one of the following types:
 
 has page_start => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_page_start',
     json_ld   => 'pageStart',
 );
 
@@ -109,7 +109,7 @@ A pagination should be one of the following types:
 
 has pagination => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pagination',
     json_ld   => 'pagination',
 );
 
@@ -136,7 +136,7 @@ A volume_number should be one of the following types:
 
 has volume_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_volume_number',
     json_ld   => 'volumeNumber',
 );
 

--- a/lib/SemanticWeb/Schema/QualitativeValue.pm
+++ b/lib/SemanticWeb/Schema/QualitativeValue.pm
@@ -60,7 +60,7 @@ A additional_property should be one of the following types:
 
 has additional_property => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_additional_property',
     json_ld   => 'additionalProperty',
 );
 
@@ -85,7 +85,7 @@ A equal should be one of the following types:
 
 has equal => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_equal',
     json_ld   => 'equal',
 );
 
@@ -110,7 +110,7 @@ A greater should be one of the following types:
 
 has greater => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_greater',
     json_ld   => 'greater',
 );
 
@@ -135,7 +135,7 @@ A greater_or_equal should be one of the following types:
 
 has greater_or_equal => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_greater_or_equal',
     json_ld   => 'greaterOrEqual',
 );
 
@@ -160,7 +160,7 @@ A lesser should be one of the following types:
 
 has lesser => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_lesser',
     json_ld   => 'lesser',
 );
 
@@ -185,7 +185,7 @@ A lesser_or_equal should be one of the following types:
 
 has lesser_or_equal => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_lesser_or_equal',
     json_ld   => 'lesserOrEqual',
 );
 
@@ -210,7 +210,7 @@ A non_equal should be one of the following types:
 
 has non_equal => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_non_equal',
     json_ld   => 'nonEqual',
 );
 
@@ -243,7 +243,7 @@ A value_reference should be one of the following types:
 
 has value_reference => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_value_reference',
     json_ld   => 'valueReference',
 );
 

--- a/lib/SemanticWeb/Schema/QuantitativeValue.pm
+++ b/lib/SemanticWeb/Schema/QuantitativeValue.pm
@@ -59,7 +59,7 @@ A additional_property should be one of the following types:
 
 has additional_property => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_additional_property',
     json_ld   => 'additionalProperty',
 );
 
@@ -83,7 +83,7 @@ A max_value should be one of the following types:
 
 has max_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_max_value',
     json_ld   => 'maxValue',
 );
 
@@ -107,7 +107,7 @@ A min_value should be one of the following types:
 
 has min_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_min_value',
     json_ld   => 'minValue',
 );
 
@@ -133,7 +133,7 @@ A unit_code should be one of the following types:
 
 has unit_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_unit_code',
     json_ld   => 'unitCode',
 );
 
@@ -162,7 +162,7 @@ A unit_text should be one of the following types:
 
 has unit_text => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_unit_text',
     json_ld   => 'unitText',
 );
 
@@ -207,7 +207,7 @@ A value should be one of the following types:
 
 has value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_value',
     json_ld   => 'value',
 );
 
@@ -240,7 +240,7 @@ A value_reference should be one of the following types:
 
 has value_reference => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_value_reference',
     json_ld   => 'valueReference',
 );
 

--- a/lib/SemanticWeb/Schema/QuantitativeValueDistribution.pm
+++ b/lib/SemanticWeb/Schema/QuantitativeValueDistribution.pm
@@ -53,7 +53,7 @@ A duration should be one of the following types:
 
 has duration => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_duration',
     json_ld   => 'duration',
 );
 
@@ -77,7 +77,7 @@ A median should be one of the following types:
 
 has median => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_median',
     json_ld   => 'median',
 );
 
@@ -101,7 +101,7 @@ A percentile10 should be one of the following types:
 
 has percentile10 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_percentile10',
     json_ld   => 'percentile10',
 );
 
@@ -125,7 +125,7 @@ A percentile25 should be one of the following types:
 
 has percentile25 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_percentile25',
     json_ld   => 'percentile25',
 );
 
@@ -149,7 +149,7 @@ A percentile75 should be one of the following types:
 
 has percentile75 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_percentile75',
     json_ld   => 'percentile75',
 );
 
@@ -173,7 +173,7 @@ A percentile90 should be one of the following types:
 
 has percentile90 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_percentile90',
     json_ld   => 'percentile90',
 );
 

--- a/lib/SemanticWeb/Schema/Question.pm
+++ b/lib/SemanticWeb/Schema/Question.pm
@@ -53,7 +53,7 @@ A accepted_answer should be one of the following types:
 
 has accepted_answer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_accepted_answer',
     json_ld   => 'acceptedAnswer',
 );
 
@@ -77,7 +77,7 @@ A answer_count should be one of the following types:
 
 has answer_count => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_answer_count',
     json_ld   => 'answerCount',
 );
 
@@ -102,7 +102,7 @@ A downvote_count should be one of the following types:
 
 has downvote_count => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_downvote_count',
     json_ld   => 'downvoteCount',
 );
 
@@ -129,7 +129,7 @@ A suggested_answer should be one of the following types:
 
 has suggested_answer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_suggested_answer',
     json_ld   => 'suggestedAnswer',
 );
 
@@ -154,7 +154,7 @@ A upvote_count should be one of the following types:
 
 has upvote_count => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_upvote_count',
     json_ld   => 'upvoteCount',
 );
 

--- a/lib/SemanticWeb/Schema/Quotation.pm
+++ b/lib/SemanticWeb/Schema/Quotation.pm
@@ -61,7 +61,7 @@ A spoken_by_character should be one of the following types:
 
 has spoken_by_character => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_spoken_by_character',
     json_ld   => 'spokenByCharacter',
 );
 

--- a/lib/SemanticWeb/Schema/RadioSeries.pm
+++ b/lib/SemanticWeb/Schema/RadioSeries.pm
@@ -51,7 +51,7 @@ A actor should be one of the following types:
 
 has actor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actor',
     json_ld   => 'actor',
 );
 
@@ -76,7 +76,7 @@ A actors should be one of the following types:
 
 has actors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actors',
     json_ld   => 'actors',
 );
 
@@ -100,7 +100,7 @@ A contains_season should be one of the following types:
 
 has contains_season => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contains_season',
     json_ld   => 'containsSeason',
 );
 
@@ -126,7 +126,7 @@ A director should be one of the following types:
 
 has director => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_director',
     json_ld   => 'director',
 );
 
@@ -151,7 +151,7 @@ A directors should be one of the following types:
 
 has directors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_directors',
     json_ld   => 'directors',
 );
 
@@ -175,7 +175,7 @@ A episode should be one of the following types:
 
 has episode => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_episode',
     json_ld   => 'episode',
 );
 
@@ -199,7 +199,7 @@ A episodes should be one of the following types:
 
 has episodes => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_episodes',
     json_ld   => 'episodes',
 );
 
@@ -225,7 +225,7 @@ A music_by should be one of the following types:
 
 has music_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_music_by',
     json_ld   => 'musicBy',
 );
 
@@ -249,7 +249,7 @@ A number_of_episodes should be one of the following types:
 
 has number_of_episodes => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_episodes',
     json_ld   => 'numberOfEpisodes',
 );
 
@@ -273,7 +273,7 @@ A number_of_seasons should be one of the following types:
 
 has number_of_seasons => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_seasons',
     json_ld   => 'numberOfSeasons',
 );
 
@@ -298,7 +298,7 @@ A production_company should be one of the following types:
 
 has production_company => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_production_company',
     json_ld   => 'productionCompany',
 );
 
@@ -322,7 +322,7 @@ A season should be one of the following types:
 
 has season => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_season',
     json_ld   => 'season',
 );
 
@@ -346,7 +346,7 @@ A seasons should be one of the following types:
 
 has seasons => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seasons',
     json_ld   => 'seasons',
 );
 
@@ -370,7 +370,7 @@ A trailer should be one of the following types:
 
 has trailer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_trailer',
     json_ld   => 'trailer',
 );
 

--- a/lib/SemanticWeb/Schema/Rating.pm
+++ b/lib/SemanticWeb/Schema/Rating.pm
@@ -52,7 +52,7 @@ A author should be one of the following types:
 
 has author => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_author',
     json_ld   => 'author',
 );
 
@@ -79,7 +79,7 @@ A best_rating should be one of the following types:
 
 has best_rating => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_best_rating',
     json_ld   => 'bestRating',
 );
 
@@ -111,7 +111,7 @@ A rating_explanation should be one of the following types:
 
 has rating_explanation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_rating_explanation',
     json_ld   => 'ratingExplanation',
 );
 
@@ -146,7 +146,7 @@ A rating_value should be one of the following types:
 
 has rating_value => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_rating_value',
     json_ld   => 'ratingValue',
 );
 
@@ -171,7 +171,7 @@ A review_aspect should be one of the following types:
 
 has review_aspect => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_review_aspect',
     json_ld   => 'reviewAspect',
 );
 
@@ -198,7 +198,7 @@ A worst_rating should be one of the following types:
 
 has worst_rating => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_worst_rating',
     json_ld   => 'worstRating',
 );
 

--- a/lib/SemanticWeb/Schema/RealEstateListing.pm
+++ b/lib/SemanticWeb/Schema/RealEstateListing.pm
@@ -69,7 +69,7 @@ A lease_length should be one of the following types:
 
 has lease_length => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_lease_length',
     json_ld   => 'leaseLength',
 );
 

--- a/lib/SemanticWeb/Schema/ReceiveAction.pm
+++ b/lib/SemanticWeb/Schema/ReceiveAction.pm
@@ -60,7 +60,7 @@ A delivery_method should be one of the following types:
 
 has delivery_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_delivery_method',
     json_ld   => 'deliveryMethod',
 );
 
@@ -89,7 +89,7 @@ A sender should be one of the following types:
 
 has sender => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sender',
     json_ld   => 'sender',
 );
 

--- a/lib/SemanticWeb/Schema/Recipe.pm
+++ b/lib/SemanticWeb/Schema/Recipe.pm
@@ -62,7 +62,7 @@ A cook_time should be one of the following types:
 
 has cook_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cook_time',
     json_ld   => 'cookTime',
 );
 
@@ -86,7 +86,7 @@ A cooking_method should be one of the following types:
 
 has cooking_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cooking_method',
     json_ld   => 'cookingMethod',
 );
 
@@ -110,7 +110,7 @@ A ingredients should be one of the following types:
 
 has ingredients => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ingredients',
     json_ld   => 'ingredients',
 );
 
@@ -134,7 +134,7 @@ A nutrition should be one of the following types:
 
 has nutrition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_nutrition',
     json_ld   => 'nutrition',
 );
 
@@ -158,7 +158,7 @@ A recipe_category should be one of the following types:
 
 has recipe_category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipe_category',
     json_ld   => 'recipeCategory',
 );
 
@@ -182,7 +182,7 @@ A recipe_cuisine should be one of the following types:
 
 has recipe_cuisine => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipe_cuisine',
     json_ld   => 'recipeCuisine',
 );
 
@@ -206,7 +206,7 @@ A recipe_ingredient should be one of the following types:
 
 has recipe_ingredient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipe_ingredient',
     json_ld   => 'recipeIngredient',
 );
 
@@ -235,7 +235,7 @@ A recipe_instructions should be one of the following types:
 
 has recipe_instructions => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipe_instructions',
     json_ld   => 'recipeInstructions',
 );
 
@@ -262,7 +262,7 @@ A recipe_yield should be one of the following types:
 
 has recipe_yield => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipe_yield',
     json_ld   => 'recipeYield',
 );
 
@@ -287,7 +287,7 @@ A suitable_for_diet should be one of the following types:
 
 has suitable_for_diet => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_suitable_for_diet',
     json_ld   => 'suitableForDiet',
 );
 

--- a/lib/SemanticWeb/Schema/RentAction.pm
+++ b/lib/SemanticWeb/Schema/RentAction.pm
@@ -52,7 +52,7 @@ A landlord should be one of the following types:
 
 has landlord => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_landlord',
     json_ld   => 'landlord',
 );
 
@@ -77,7 +77,7 @@ A real_estate_agent should be one of the following types:
 
 has real_estate_agent => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_real_estate_agent',
     json_ld   => 'realEstateAgent',
 );
 

--- a/lib/SemanticWeb/Schema/RentalCarReservation.pm
+++ b/lib/SemanticWeb/Schema/RentalCarReservation.pm
@@ -54,7 +54,7 @@ A dropoff_location should be one of the following types:
 
 has dropoff_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_dropoff_location',
     json_ld   => 'dropoffLocation',
 );
 
@@ -78,7 +78,7 @@ A dropoff_time should be one of the following types:
 
 has dropoff_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_dropoff_time',
     json_ld   => 'dropoffTime',
 );
 
@@ -102,7 +102,7 @@ A pickup_location should be one of the following types:
 
 has pickup_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pickup_location',
     json_ld   => 'pickupLocation',
 );
 
@@ -126,7 +126,7 @@ A pickup_time should be one of the following types:
 
 has pickup_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pickup_time',
     json_ld   => 'pickupTime',
 );
 

--- a/lib/SemanticWeb/Schema/RepaymentSpecification.pm
+++ b/lib/SemanticWeb/Schema/RepaymentSpecification.pm
@@ -52,7 +52,7 @@ A down_payment should be one of the following types:
 
 has down_payment => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_down_payment',
     json_ld   => 'downPayment',
 );
 
@@ -77,7 +77,7 @@ A early_prepayment_penalty should be one of the following types:
 
 has early_prepayment_penalty => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_early_prepayment_penalty',
     json_ld   => 'earlyPrepaymentPenalty',
 );
 
@@ -101,7 +101,7 @@ A loan_payment_amount should be one of the following types:
 
 has loan_payment_amount => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_loan_payment_amount',
     json_ld   => 'loanPaymentAmount',
 );
 
@@ -126,7 +126,7 @@ A loan_payment_frequency should be one of the following types:
 
 has loan_payment_frequency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_loan_payment_frequency',
     json_ld   => 'loanPaymentFrequency',
 );
 
@@ -152,7 +152,7 @@ A number_of_loan_payments should be one of the following types:
 
 has number_of_loan_payments => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_loan_payments',
     json_ld   => 'numberOfLoanPayments',
 );
 

--- a/lib/SemanticWeb/Schema/ReplaceAction.pm
+++ b/lib/SemanticWeb/Schema/ReplaceAction.pm
@@ -49,7 +49,7 @@ A replacee should be one of the following types:
 
 has replacee => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_replacee',
     json_ld   => 'replacee',
 );
 
@@ -73,7 +73,7 @@ A replacer should be one of the following types:
 
 has replacer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_replacer',
     json_ld   => 'replacer',
 );
 

--- a/lib/SemanticWeb/Schema/ReplyAction.pm
+++ b/lib/SemanticWeb/Schema/ReplyAction.pm
@@ -58,7 +58,7 @@ A result_comment should be one of the following types:
 
 has result_comment => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_result_comment',
     json_ld   => 'resultComment',
 );
 

--- a/lib/SemanticWeb/Schema/Report.pm
+++ b/lib/SemanticWeb/Schema/Report.pm
@@ -49,7 +49,7 @@ A report_number should be one of the following types:
 
 has report_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_report_number',
     json_ld   => 'reportNumber',
 );
 

--- a/lib/SemanticWeb/Schema/Reservation.pm
+++ b/lib/SemanticWeb/Schema/Reservation.pm
@@ -60,7 +60,7 @@ A booking_agent should be one of the following types:
 
 has booking_agent => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_booking_agent',
     json_ld   => 'bookingAgent',
 );
 
@@ -84,7 +84,7 @@ A booking_time should be one of the following types:
 
 has booking_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_booking_time',
     json_ld   => 'bookingTime',
 );
 
@@ -113,7 +113,7 @@ A broker should be one of the following types:
 
 has broker => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broker',
     json_ld   => 'broker',
 );
 
@@ -137,7 +137,7 @@ A modified_time should be one of the following types:
 
 has modified_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_modified_time',
     json_ld   => 'modifiedTime',
 );
 
@@ -175,7 +175,7 @@ A price_currency should be one of the following types:
 
 has price_currency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price_currency',
     json_ld   => 'priceCurrency',
 );
 
@@ -200,7 +200,7 @@ A program_membership_used should be one of the following types:
 
 has program_membership_used => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_program_membership_used',
     json_ld   => 'programMembershipUsed',
 );
 
@@ -228,7 +228,7 @@ A provider should be one of the following types:
 
 has provider => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_provider',
     json_ld   => 'provider',
 );
 
@@ -252,7 +252,7 @@ A reservation_for should be one of the following types:
 
 has reservation_for => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_reservation_for',
     json_ld   => 'reservationFor',
 );
 
@@ -276,7 +276,7 @@ A reservation_id should be one of the following types:
 
 has reservation_id => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_reservation_id',
     json_ld   => 'reservationId',
 );
 
@@ -300,7 +300,7 @@ A reservation_status should be one of the following types:
 
 has reservation_status => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_reservation_status',
     json_ld   => 'reservationStatus',
 );
 
@@ -324,7 +324,7 @@ A reserved_ticket should be one of the following types:
 
 has reserved_ticket => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_reserved_ticket',
     json_ld   => 'reservedTicket',
 );
 
@@ -361,7 +361,7 @@ A total_price should be one of the following types:
 
 has total_price => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_total_price',
     json_ld   => 'totalPrice',
 );
 
@@ -387,7 +387,7 @@ A under_name should be one of the following types:
 
 has under_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_under_name',
     json_ld   => 'underName',
 );
 

--- a/lib/SemanticWeb/Schema/ReservationPackage.pm
+++ b/lib/SemanticWeb/Schema/ReservationPackage.pm
@@ -50,7 +50,7 @@ A sub_reservation should be one of the following types:
 
 has sub_reservation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sub_reservation',
     json_ld   => 'subReservation',
 );
 

--- a/lib/SemanticWeb/Schema/ReturnAction.pm
+++ b/lib/SemanticWeb/Schema/ReturnAction.pm
@@ -56,7 +56,7 @@ A recipient should be one of the following types:
 
 has recipient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipient',
     json_ld   => 'recipient',
 );
 

--- a/lib/SemanticWeb/Schema/Review.pm
+++ b/lib/SemanticWeb/Schema/Review.pm
@@ -48,7 +48,7 @@ A item_reviewed should be one of the following types:
 
 has item_reviewed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_item_reviewed',
     json_ld   => 'itemReviewed',
 );
 
@@ -73,7 +73,7 @@ A review_aspect should be one of the following types:
 
 has review_aspect => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_review_aspect',
     json_ld   => 'reviewAspect',
 );
 
@@ -97,7 +97,7 @@ A review_body should be one of the following types:
 
 has review_body => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_review_body',
     json_ld   => 'reviewBody',
 );
 
@@ -129,7 +129,7 @@ A review_rating should be one of the following types:
 
 has review_rating => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_review_rating',
     json_ld   => 'reviewRating',
 );
 

--- a/lib/SemanticWeb/Schema/ReviewAction.pm
+++ b/lib/SemanticWeb/Schema/ReviewAction.pm
@@ -50,7 +50,7 @@ A result_review should be one of the following types:
 
 has result_review => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_result_review',
     json_ld   => 'resultReview',
 );
 

--- a/lib/SemanticWeb/Schema/Role.pm
+++ b/lib/SemanticWeb/Schema/Role.pm
@@ -65,7 +65,7 @@ A end_date should be one of the following types:
 
 has end_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_end_date',
     json_ld   => 'endDate',
 );
 
@@ -91,7 +91,7 @@ A named_position should be one of the following types:
 
 has named_position => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_named_position',
     json_ld   => 'namedPosition',
 );
 
@@ -118,7 +118,7 @@ A role_name should be one of the following types:
 
 has role_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_role_name',
     json_ld   => 'roleName',
 );
 
@@ -147,7 +147,7 @@ A start_date should be one of the following types:
 
 has start_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_start_date',
     json_ld   => 'startDate',
 );
 

--- a/lib/SemanticWeb/Schema/RsvpAction.pm
+++ b/lib/SemanticWeb/Schema/RsvpAction.pm
@@ -50,7 +50,7 @@ A additional_number_of_guests should be one of the following types:
 
 has additional_number_of_guests => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_additional_number_of_guests',
     json_ld   => 'additionalNumberOfGuests',
 );
 
@@ -74,7 +74,7 @@ A comment should be one of the following types:
 
 has comment => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_comment',
     json_ld   => 'comment',
 );
 
@@ -98,7 +98,7 @@ A rsvp_response should be one of the following types:
 
 has rsvp_response => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_rsvp_response',
     json_ld   => 'rsvpResponse',
 );
 

--- a/lib/SemanticWeb/Schema/Schedule.pm
+++ b/lib/SemanticWeb/Schema/Schedule.pm
@@ -66,7 +66,7 @@ A by_day should be one of the following types:
 
 has by_day => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_by_day',
     json_ld   => 'byDay',
 );
 
@@ -97,7 +97,7 @@ A by_month should be one of the following types:
 
 has by_month => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_by_month',
     json_ld   => 'byMonth',
 );
 
@@ -128,7 +128,7 @@ A by_month_day should be one of the following types:
 
 has by_month_day => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_by_month_day',
     json_ld   => 'byMonthDay',
 );
 
@@ -173,7 +173,7 @@ A event_schedule should be one of the following types:
 
 has event_schedule => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_event_schedule',
     json_ld   => 'eventSchedule',
 );
 
@@ -214,7 +214,7 @@ A except_date should be one of the following types:
 
 has except_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_except_date',
     json_ld   => 'exceptDate',
 );
 
@@ -243,7 +243,7 @@ A repeat_count should be one of the following types:
 
 has repeat_count => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_repeat_count',
     json_ld   => 'repeatCount',
 );
 
@@ -278,7 +278,7 @@ A repeat_frequency should be one of the following types:
 
 has repeat_frequency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_repeat_frequency',
     json_ld   => 'repeatFrequency',
 );
 

--- a/lib/SemanticWeb/Schema/ScreeningEvent.pm
+++ b/lib/SemanticWeb/Schema/ScreeningEvent.pm
@@ -55,7 +55,7 @@ A subtitle_language should be one of the following types:
 
 has subtitle_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_subtitle_language',
     json_ld   => 'subtitleLanguage',
 );
 
@@ -80,7 +80,7 @@ A video_format should be one of the following types:
 
 has video_format => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_video_format',
     json_ld   => 'videoFormat',
 );
 
@@ -104,7 +104,7 @@ A work_presented should be one of the following types:
 
 has work_presented => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_work_presented',
     json_ld   => 'workPresented',
 );
 

--- a/lib/SemanticWeb/Schema/SearchAction.pm
+++ b/lib/SemanticWeb/Schema/SearchAction.pm
@@ -55,7 +55,7 @@ A query should be one of the following types:
 
 has query => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_query',
     json_ld   => 'query',
 );
 

--- a/lib/SemanticWeb/Schema/Seat.pm
+++ b/lib/SemanticWeb/Schema/Seat.pm
@@ -48,7 +48,7 @@ A seat_number should be one of the following types:
 
 has seat_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seat_number',
     json_ld   => 'seatNumber',
 );
 
@@ -72,7 +72,7 @@ A seat_row should be one of the following types:
 
 has seat_row => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seat_row',
     json_ld   => 'seatRow',
 );
 
@@ -96,7 +96,7 @@ A seat_section should be one of the following types:
 
 has seat_section => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seat_section',
     json_ld   => 'seatSection',
 );
 
@@ -122,7 +122,7 @@ A seating_type should be one of the following types:
 
 has seating_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seating_type',
     json_ld   => 'seatingType',
 );
 

--- a/lib/SemanticWeb/Schema/SellAction.pm
+++ b/lib/SemanticWeb/Schema/SellAction.pm
@@ -51,7 +51,7 @@ A buyer should be one of the following types:
 
 has buyer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_buyer',
     json_ld   => 'buyer',
 );
 
@@ -75,7 +75,7 @@ A warranty_promise should be one of the following types:
 
 has warranty_promise => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_warranty_promise',
     json_ld   => 'warrantyPromise',
 );
 

--- a/lib/SemanticWeb/Schema/SendAction.pm
+++ b/lib/SemanticWeb/Schema/SendAction.pm
@@ -58,7 +58,7 @@ A delivery_method should be one of the following types:
 
 has delivery_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_delivery_method',
     json_ld   => 'deliveryMethod',
 );
 
@@ -89,7 +89,7 @@ A recipient should be one of the following types:
 
 has recipient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipient',
     json_ld   => 'recipient',
 );
 

--- a/lib/SemanticWeb/Schema/Service.pm
+++ b/lib/SemanticWeb/Schema/Service.pm
@@ -50,7 +50,7 @@ A aggregate_rating should be one of the following types:
 
 has aggregate_rating => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_aggregate_rating',
     json_ld   => 'aggregateRating',
 );
 
@@ -80,7 +80,7 @@ A area_served should be one of the following types:
 
 has area_served => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_area_served',
     json_ld   => 'areaServed',
 );
 
@@ -104,7 +104,7 @@ A audience should be one of the following types:
 
 has audience => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_audience',
     json_ld   => 'audience',
 );
 
@@ -129,7 +129,7 @@ A available_channel should be one of the following types:
 
 has available_channel => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_channel',
     json_ld   => 'availableChannel',
 );
 
@@ -153,7 +153,7 @@ A award should be one of the following types:
 
 has award => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_award',
     json_ld   => 'award',
 );
 
@@ -180,7 +180,7 @@ A brand should be one of the following types:
 
 has brand => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_brand',
     json_ld   => 'brand',
 );
 
@@ -209,7 +209,7 @@ A broker should be one of the following types:
 
 has broker => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_broker',
     json_ld   => 'broker',
 );
 
@@ -238,7 +238,7 @@ A category should be one of the following types:
 
 has category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_category',
     json_ld   => 'category',
 );
 
@@ -263,7 +263,7 @@ A has_offer_catalog should be one of the following types:
 
 has has_offer_catalog => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_has_offer_catalog',
     json_ld   => 'hasOfferCatalog',
 );
 
@@ -287,7 +287,7 @@ A hours_available should be one of the following types:
 
 has hours_available => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_hours_available',
     json_ld   => 'hoursAvailable',
 );
 
@@ -313,7 +313,7 @@ A is_related_to should be one of the following types:
 
 has is_related_to => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_related_to',
     json_ld   => 'isRelatedTo',
 );
 
@@ -339,7 +339,7 @@ A is_similar_to should be one of the following types:
 
 has is_similar_to => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_is_similar_to',
     json_ld   => 'isSimilarTo',
 );
 
@@ -365,7 +365,7 @@ A logo should be one of the following types:
 
 has logo => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_logo',
     json_ld   => 'logo',
 );
 
@@ -391,7 +391,7 @@ A offers should be one of the following types:
 
 has offers => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_offers',
     json_ld   => 'offers',
 );
 
@@ -415,7 +415,7 @@ A produces should be one of the following types:
 
 has produces => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_produces',
     json_ld   => 'produces',
 );
 
@@ -443,7 +443,7 @@ A provider should be one of the following types:
 
 has provider => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_provider',
     json_ld   => 'provider',
 );
 
@@ -467,7 +467,7 @@ A provider_mobility should be one of the following types:
 
 has provider_mobility => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_provider_mobility',
     json_ld   => 'providerMobility',
 );
 
@@ -491,7 +491,7 @@ A review should be one of the following types:
 
 has review => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_review',
     json_ld   => 'review',
 );
 
@@ -519,7 +519,7 @@ A service_area should be one of the following types:
 
 has service_area => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_service_area',
     json_ld   => 'serviceArea',
 );
 
@@ -543,7 +543,7 @@ A service_audience should be one of the following types:
 
 has service_audience => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_service_audience',
     json_ld   => 'serviceAudience',
 );
 
@@ -567,7 +567,7 @@ A service_output should be one of the following types:
 
 has service_output => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_service_output',
     json_ld   => 'serviceOutput',
 );
 
@@ -592,7 +592,7 @@ A service_type should be one of the following types:
 
 has service_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_service_type',
     json_ld   => 'serviceType',
 );
 
@@ -616,7 +616,7 @@ A slogan should be one of the following types:
 
 has slogan => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_slogan',
     json_ld   => 'slogan',
 );
 
@@ -640,7 +640,7 @@ A terms_of_service should be one of the following types:
 
 has terms_of_service => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_terms_of_service',
     json_ld   => 'termsOfService',
 );
 

--- a/lib/SemanticWeb/Schema/ServiceChannel.pm
+++ b/lib/SemanticWeb/Schema/ServiceChannel.pm
@@ -58,7 +58,7 @@ A available_language should be one of the following types:
 
 has available_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_language',
     json_ld   => 'availableLanguage',
 );
 
@@ -82,7 +82,7 @@ A processing_time should be one of the following types:
 
 has processing_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_processing_time',
     json_ld   => 'processingTime',
 );
 
@@ -106,7 +106,7 @@ A provides_service should be one of the following types:
 
 has provides_service => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_provides_service',
     json_ld   => 'providesService',
 );
 
@@ -131,7 +131,7 @@ A service_location should be one of the following types:
 
 has service_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_service_location',
     json_ld   => 'serviceLocation',
 );
 
@@ -155,7 +155,7 @@ A service_phone should be one of the following types:
 
 has service_phone => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_service_phone',
     json_ld   => 'servicePhone',
 );
 
@@ -179,7 +179,7 @@ A service_postal_address should be one of the following types:
 
 has service_postal_address => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_service_postal_address',
     json_ld   => 'servicePostalAddress',
 );
 
@@ -203,7 +203,7 @@ A service_sms_number should be one of the following types:
 
 has service_sms_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_service_sms_number',
     json_ld   => 'serviceSmsNumber',
 );
 
@@ -227,7 +227,7 @@ A service_url should be one of the following types:
 
 has service_url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_service_url',
     json_ld   => 'serviceUrl',
 );
 

--- a/lib/SemanticWeb/Schema/SingleFamilyResidence.pm
+++ b/lib/SemanticWeb/Schema/SingleFamilyResidence.pm
@@ -53,7 +53,7 @@ A number_of_rooms should be one of the following types:
 
 has number_of_rooms => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_rooms',
     json_ld   => 'numberOfRooms',
 );
 
@@ -81,7 +81,7 @@ A occupancy should be one of the following types:
 
 has occupancy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_occupancy',
     json_ld   => 'occupancy',
 );
 

--- a/lib/SemanticWeb/Schema/SocialMediaPosting.pm
+++ b/lib/SemanticWeb/Schema/SocialMediaPosting.pm
@@ -50,7 +50,7 @@ A shared_content should be one of the following types:
 
 has shared_content => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_shared_content',
     json_ld   => 'sharedContent',
 );
 

--- a/lib/SemanticWeb/Schema/SoftwareApplication.pm
+++ b/lib/SemanticWeb/Schema/SoftwareApplication.pm
@@ -48,7 +48,7 @@ A application_category should be one of the following types:
 
 has application_category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_application_category',
     json_ld   => 'applicationCategory',
 );
 
@@ -72,7 +72,7 @@ A application_sub_category should be one of the following types:
 
 has application_sub_category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_application_sub_category',
     json_ld   => 'applicationSubCategory',
 );
 
@@ -97,7 +97,7 @@ A application_suite should be one of the following types:
 
 has application_suite => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_application_suite',
     json_ld   => 'applicationSuite',
 );
 
@@ -122,7 +122,7 @@ A available_on_device should be one of the following types:
 
 has available_on_device => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_on_device',
     json_ld   => 'availableOnDevice',
 );
 
@@ -147,7 +147,7 @@ A countries_not_supported should be one of the following types:
 
 has countries_not_supported => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_countries_not_supported',
     json_ld   => 'countriesNotSupported',
 );
 
@@ -172,7 +172,7 @@ A countries_supported should be one of the following types:
 
 has countries_supported => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_countries_supported',
     json_ld   => 'countriesSupported',
 );
 
@@ -197,7 +197,7 @@ A device should be one of the following types:
 
 has device => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_device',
     json_ld   => 'device',
 );
 
@@ -221,7 +221,7 @@ A download_url should be one of the following types:
 
 has download_url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_download_url',
     json_ld   => 'downloadUrl',
 );
 
@@ -246,7 +246,7 @@ A feature_list should be one of the following types:
 
 has feature_list => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_feature_list',
     json_ld   => 'featureList',
 );
 
@@ -271,7 +271,7 @@ A file_size should be one of the following types:
 
 has file_size => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_file_size',
     json_ld   => 'fileSize',
 );
 
@@ -296,7 +296,7 @@ A install_url should be one of the following types:
 
 has install_url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_install_url',
     json_ld   => 'installUrl',
 );
 
@@ -320,7 +320,7 @@ A memory_requirements should be one of the following types:
 
 has memory_requirements => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_memory_requirements',
     json_ld   => 'memoryRequirements',
 );
 
@@ -344,7 +344,7 @@ A operating_system should be one of the following types:
 
 has operating_system => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_operating_system',
     json_ld   => 'operatingSystem',
 );
 
@@ -369,7 +369,7 @@ A permissions should be one of the following types:
 
 has permissions => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_permissions',
     json_ld   => 'permissions',
 );
 
@@ -393,7 +393,7 @@ A processor_requirements should be one of the following types:
 
 has processor_requirements => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_processor_requirements',
     json_ld   => 'processorRequirements',
 );
 
@@ -417,7 +417,7 @@ A release_notes should be one of the following types:
 
 has release_notes => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_release_notes',
     json_ld   => 'releaseNotes',
 );
 
@@ -444,7 +444,7 @@ A requirements should be one of the following types:
 
 has requirements => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_requirements',
     json_ld   => 'requirements',
 );
 
@@ -470,7 +470,7 @@ A screenshot should be one of the following types:
 
 has screenshot => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_screenshot',
     json_ld   => 'screenshot',
 );
 
@@ -494,7 +494,7 @@ A software_add_on should be one of the following types:
 
 has software_add_on => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_software_add_on',
     json_ld   => 'softwareAddOn',
 );
 
@@ -518,7 +518,7 @@ A software_help should be one of the following types:
 
 has software_help => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_software_help',
     json_ld   => 'softwareHelp',
 );
 
@@ -545,7 +545,7 @@ A software_requirements should be one of the following types:
 
 has software_requirements => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_software_requirements',
     json_ld   => 'softwareRequirements',
 );
 
@@ -569,7 +569,7 @@ A software_version should be one of the following types:
 
 has software_version => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_software_version',
     json_ld   => 'softwareVersion',
 );
 
@@ -593,7 +593,7 @@ A storage_requirements should be one of the following types:
 
 has storage_requirements => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_storage_requirements',
     json_ld   => 'storageRequirements',
 );
 
@@ -617,7 +617,7 @@ A supporting_data should be one of the following types:
 
 has supporting_data => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_supporting_data',
     json_ld   => 'supportingData',
 );
 

--- a/lib/SemanticWeb/Schema/SoftwareSourceCode.pm
+++ b/lib/SemanticWeb/Schema/SoftwareSourceCode.pm
@@ -50,7 +50,7 @@ A code_repository should be one of the following types:
 
 has code_repository => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_code_repository',
     json_ld   => 'codeRepository',
 );
 
@@ -75,7 +75,7 @@ A code_sample_type should be one of the following types:
 
 has code_sample_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_code_sample_type',
     json_ld   => 'codeSampleType',
 );
 
@@ -101,7 +101,7 @@ A programming_language should be one of the following types:
 
 has programming_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_programming_language',
     json_ld   => 'programmingLanguage',
 );
 
@@ -126,7 +126,7 @@ A runtime should be one of the following types:
 
 has runtime => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_runtime',
     json_ld   => 'runtime',
 );
 
@@ -151,7 +151,7 @@ A runtime_platform should be one of the following types:
 
 has runtime_platform => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_runtime_platform',
     json_ld   => 'runtimePlatform',
 );
 
@@ -176,7 +176,7 @@ A sample_type should be one of the following types:
 
 has sample_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sample_type',
     json_ld   => 'sampleType',
 );
 
@@ -201,7 +201,7 @@ A target_product should be one of the following types:
 
 has target_product => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_target_product',
     json_ld   => 'targetProduct',
 );
 

--- a/lib/SemanticWeb/Schema/SomeProducts.pm
+++ b/lib/SemanticWeb/Schema/SomeProducts.pm
@@ -48,7 +48,7 @@ A inventory_level should be one of the following types:
 
 has inventory_level => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_inventory_level',
     json_ld   => 'inventoryLevel',
 );
 

--- a/lib/SemanticWeb/Schema/SpeakableSpecification.pm
+++ b/lib/SemanticWeb/Schema/SpeakableSpecification.pm
@@ -67,7 +67,7 @@ A css_selector should be one of the following types:
 
 has css_selector => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_css_selector',
     json_ld   => 'cssSelector',
 );
 
@@ -100,7 +100,7 @@ A xpath should be one of the following types:
 
 has xpath => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_xpath',
     json_ld   => 'xpath',
 );
 

--- a/lib/SemanticWeb/Schema/SportsEvent.pm
+++ b/lib/SemanticWeb/Schema/SportsEvent.pm
@@ -50,7 +50,7 @@ A away_team should be one of the following types:
 
 has away_team => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_away_team',
     json_ld   => 'awayTeam',
 );
 
@@ -76,7 +76,7 @@ A competitor should be one of the following types:
 
 has competitor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_competitor',
     json_ld   => 'competitor',
 );
 
@@ -102,7 +102,7 @@ A home_team should be one of the following types:
 
 has home_team => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_home_team',
     json_ld   => 'homeTeam',
 );
 

--- a/lib/SemanticWeb/Schema/SportsOrganization.pm
+++ b/lib/SemanticWeb/Schema/SportsOrganization.pm
@@ -49,7 +49,7 @@ A sport should be one of the following types:
 
 has sport => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sport',
     json_ld   => 'sport',
 );
 

--- a/lib/SemanticWeb/Schema/SportsTeam.pm
+++ b/lib/SemanticWeb/Schema/SportsTeam.pm
@@ -49,7 +49,7 @@ A athlete should be one of the following types:
 
 has athlete => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_athlete',
     json_ld   => 'athlete',
 );
 
@@ -73,7 +73,7 @@ A coach should be one of the following types:
 
 has coach => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_coach',
     json_ld   => 'coach',
 );
 
@@ -113,7 +113,7 @@ A gender should be one of the following types:
 
 has gender => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_gender',
     json_ld   => 'gender',
 );
 

--- a/lib/SemanticWeb/Schema/StatisticalPopulation.pm
+++ b/lib/SemanticWeb/Schema/StatisticalPopulation.pm
@@ -92,7 +92,7 @@ A constraining_property should be one of the following types:
 
 has constraining_property => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_constraining_property',
     json_ld   => 'constrainingProperty',
 );
 
@@ -127,7 +127,7 @@ A num_constraints should be one of the following types:
 
 has num_constraints => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_num_constraints',
     json_ld   => 'numConstraints',
 );
 
@@ -158,7 +158,7 @@ A population_type should be one of the following types:
 
 has population_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_population_type',
     json_ld   => 'populationType',
 );
 

--- a/lib/SemanticWeb/Schema/Substance.pm
+++ b/lib/SemanticWeb/Schema/Substance.pm
@@ -50,7 +50,7 @@ A active_ingredient should be one of the following types:
 
 has active_ingredient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_active_ingredient',
     json_ld   => 'activeIngredient',
 );
 
@@ -75,7 +75,7 @@ A maximum_intake should be one of the following types:
 
 has maximum_intake => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_maximum_intake',
     json_ld   => 'maximumIntake',
 );
 

--- a/lib/SemanticWeb/Schema/Suite.pm
+++ b/lib/SemanticWeb/Schema/Suite.pm
@@ -65,7 +65,7 @@ A bed should be one of the following types:
 
 has bed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_bed',
     json_ld   => 'bed',
 );
 
@@ -94,7 +94,7 @@ A number_of_rooms should be one of the following types:
 
 has number_of_rooms => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_rooms',
     json_ld   => 'numberOfRooms',
 );
 
@@ -122,7 +122,7 @@ A occupancy should be one of the following types:
 
 has occupancy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_occupancy',
     json_ld   => 'occupancy',
 );
 

--- a/lib/SemanticWeb/Schema/SuperficialAnatomy.pm
+++ b/lib/SemanticWeb/Schema/SuperficialAnatomy.pm
@@ -67,7 +67,7 @@ A associated_pathophysiology should be one of the following types:
 
 has associated_pathophysiology => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_associated_pathophysiology',
     json_ld   => 'associatedPathophysiology',
 );
 
@@ -93,7 +93,7 @@ A related_anatomy should be one of the following types:
 
 has related_anatomy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_related_anatomy',
     json_ld   => 'relatedAnatomy',
 );
 
@@ -117,7 +117,7 @@ A related_condition should be one of the following types:
 
 has related_condition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_related_condition',
     json_ld   => 'relatedCondition',
 );
 
@@ -141,7 +141,7 @@ A related_therapy should be one of the following types:
 
 has related_therapy => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_related_therapy',
     json_ld   => 'relatedTherapy',
 );
 
@@ -167,7 +167,7 @@ A significance should be one of the following types:
 
 has significance => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_significance',
     json_ld   => 'significance',
 );
 

--- a/lib/SemanticWeb/Schema/TVClip.pm
+++ b/lib/SemanticWeb/Schema/TVClip.pm
@@ -48,7 +48,7 @@ A part_of_tv_series should be one of the following types:
 
 has part_of_tv_series => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_part_of_tv_series',
     json_ld   => 'partOfTVSeries',
 );
 

--- a/lib/SemanticWeb/Schema/TVEpisode.pm
+++ b/lib/SemanticWeb/Schema/TVEpisode.pm
@@ -49,7 +49,7 @@ A country_of_origin should be one of the following types:
 
 has country_of_origin => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_country_of_origin',
     json_ld   => 'countryOfOrigin',
 );
 
@@ -73,7 +73,7 @@ A part_of_tv_series should be one of the following types:
 
 has part_of_tv_series => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_part_of_tv_series',
     json_ld   => 'partOfTVSeries',
 );
 
@@ -104,7 +104,7 @@ A subtitle_language should be one of the following types:
 
 has subtitle_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_subtitle_language',
     json_ld   => 'subtitleLanguage',
 );
 

--- a/lib/SemanticWeb/Schema/TVSeason.pm
+++ b/lib/SemanticWeb/Schema/TVSeason.pm
@@ -49,7 +49,7 @@ A country_of_origin should be one of the following types:
 
 has country_of_origin => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_country_of_origin',
     json_ld   => 'countryOfOrigin',
 );
 
@@ -73,7 +73,7 @@ A part_of_tv_series should be one of the following types:
 
 has part_of_tv_series => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_part_of_tv_series',
     json_ld   => 'partOfTVSeries',
 );
 

--- a/lib/SemanticWeb/Schema/TVSeries.pm
+++ b/lib/SemanticWeb/Schema/TVSeries.pm
@@ -51,7 +51,7 @@ A actor should be one of the following types:
 
 has actor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actor',
     json_ld   => 'actor',
 );
 
@@ -76,7 +76,7 @@ A actors should be one of the following types:
 
 has actors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actors',
     json_ld   => 'actors',
 );
 
@@ -100,7 +100,7 @@ A contains_season should be one of the following types:
 
 has contains_season => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contains_season',
     json_ld   => 'containsSeason',
 );
 
@@ -125,7 +125,7 @@ A country_of_origin should be one of the following types:
 
 has country_of_origin => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_country_of_origin',
     json_ld   => 'countryOfOrigin',
 );
 
@@ -151,7 +151,7 @@ A director should be one of the following types:
 
 has director => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_director',
     json_ld   => 'director',
 );
 
@@ -176,7 +176,7 @@ A directors should be one of the following types:
 
 has directors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_directors',
     json_ld   => 'directors',
 );
 
@@ -200,7 +200,7 @@ A episode should be one of the following types:
 
 has episode => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_episode',
     json_ld   => 'episode',
 );
 
@@ -224,7 +224,7 @@ A episodes should be one of the following types:
 
 has episodes => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_episodes',
     json_ld   => 'episodes',
 );
 
@@ -250,7 +250,7 @@ A music_by should be one of the following types:
 
 has music_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_music_by',
     json_ld   => 'musicBy',
 );
 
@@ -274,7 +274,7 @@ A number_of_episodes should be one of the following types:
 
 has number_of_episodes => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_episodes',
     json_ld   => 'numberOfEpisodes',
 );
 
@@ -298,7 +298,7 @@ A number_of_seasons should be one of the following types:
 
 has number_of_seasons => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_seasons',
     json_ld   => 'numberOfSeasons',
 );
 
@@ -323,7 +323,7 @@ A production_company should be one of the following types:
 
 has production_company => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_production_company',
     json_ld   => 'productionCompany',
 );
 
@@ -347,7 +347,7 @@ A season should be one of the following types:
 
 has season => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_season',
     json_ld   => 'season',
 );
 
@@ -371,7 +371,7 @@ A seasons should be one of the following types:
 
 has seasons => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seasons',
     json_ld   => 'seasons',
 );
 
@@ -395,7 +395,7 @@ A trailer should be one of the following types:
 
 has trailer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_trailer',
     json_ld   => 'trailer',
 );
 

--- a/lib/SemanticWeb/Schema/TaxiReservation.pm
+++ b/lib/SemanticWeb/Schema/TaxiReservation.pm
@@ -57,7 +57,7 @@ A party_size should be one of the following types:
 
 has party_size => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_party_size',
     json_ld   => 'partySize',
 );
 
@@ -81,7 +81,7 @@ A pickup_location should be one of the following types:
 
 has pickup_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pickup_location',
     json_ld   => 'pickupLocation',
 );
 
@@ -105,7 +105,7 @@ A pickup_time should be one of the following types:
 
 has pickup_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_pickup_time',
     json_ld   => 'pickupTime',
 );
 

--- a/lib/SemanticWeb/Schema/TechArticle.pm
+++ b/lib/SemanticWeb/Schema/TechArticle.pm
@@ -49,7 +49,7 @@ A dependencies should be one of the following types:
 
 has dependencies => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_dependencies',
     json_ld   => 'dependencies',
 );
 
@@ -73,7 +73,7 @@ A proficiency_level should be one of the following types:
 
 has proficiency_level => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_proficiency_level',
     json_ld   => 'proficiencyLevel',
 );
 

--- a/lib/SemanticWeb/Schema/TherapeuticProcedure.pm
+++ b/lib/SemanticWeb/Schema/TherapeuticProcedure.pm
@@ -53,7 +53,7 @@ A adverse_outcome should be one of the following types:
 
 has adverse_outcome => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_adverse_outcome',
     json_ld   => 'adverseOutcome',
 );
 
@@ -78,7 +78,7 @@ A dose_schedule should be one of the following types:
 
 has dose_schedule => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_dose_schedule',
     json_ld   => 'doseSchedule',
 );
 
@@ -102,7 +102,7 @@ A drug should be one of the following types:
 
 has drug => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_drug',
     json_ld   => 'drug',
 );
 
@@ -130,7 +130,7 @@ A indication should be one of the following types:
 
 has indication => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_indication',
     json_ld   => 'indication',
 );
 

--- a/lib/SemanticWeb/Schema/Thesis.pm
+++ b/lib/SemanticWeb/Schema/Thesis.pm
@@ -49,7 +49,7 @@ A in_support_of should be one of the following types:
 
 has in_support_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_in_support_of',
     json_ld   => 'inSupportOf',
 );
 

--- a/lib/SemanticWeb/Schema/Thing.pm
+++ b/lib/SemanticWeb/Schema/Thing.pm
@@ -53,7 +53,7 @@ A additional_type should be one of the following types:
 
 has additional_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_additional_type',
     json_ld   => 'additionalType',
 );
 
@@ -77,7 +77,7 @@ A alternate_name should be one of the following types:
 
 has alternate_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_alternate_name',
     json_ld   => 'alternateName',
 );
 
@@ -101,7 +101,7 @@ A description should be one of the following types:
 
 has description => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_description',
     json_ld   => 'description',
 );
 
@@ -128,7 +128,7 @@ A disambiguating_description should be one of the following types:
 
 has disambiguating_description => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_disambiguating_description',
     json_ld   => 'disambiguatingDescription',
 );
 
@@ -163,7 +163,7 @@ A identifier should be one of the following types:
 
 has identifier => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_identifier',
     json_ld   => 'identifier',
 );
 
@@ -195,7 +195,7 @@ A image should be one of the following types:
 
 has image => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_image',
     json_ld   => 'image',
 );
 
@@ -228,7 +228,7 @@ A main_entity_of_page should be one of the following types:
 
 has main_entity_of_page => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_main_entity_of_page',
     json_ld   => 'mainEntityOfPage',
 );
 
@@ -252,7 +252,7 @@ A name should be one of the following types:
 
 has name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_name',
     json_ld   => 'name',
 );
 
@@ -277,7 +277,7 @@ A potential_action should be one of the following types:
 
 has potential_action => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_potential_action',
     json_ld   => 'potentialAction',
 );
 
@@ -303,7 +303,7 @@ A same_as should be one of the following types:
 
 has same_as => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_same_as',
     json_ld   => 'sameAs',
 );
 
@@ -329,7 +329,7 @@ A subject_of should be one of the following types:
 
 has subject_of => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_subject_of',
     json_ld   => 'subjectOf',
 );
 
@@ -353,7 +353,7 @@ A url should be one of the following types:
 
 has url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_url',
     json_ld   => 'url',
 );
 

--- a/lib/SemanticWeb/Schema/Ticket.pm
+++ b/lib/SemanticWeb/Schema/Ticket.pm
@@ -48,7 +48,7 @@ A date_issued should be one of the following types:
 
 has date_issued => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_date_issued',
     json_ld   => 'dateIssued',
 );
 
@@ -72,7 +72,7 @@ A issued_by should be one of the following types:
 
 has issued_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_issued_by',
     json_ld   => 'issuedBy',
 );
 
@@ -110,7 +110,7 @@ A price_currency should be one of the following types:
 
 has price_currency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price_currency',
     json_ld   => 'priceCurrency',
 );
 
@@ -134,7 +134,7 @@ A ticket_number should be one of the following types:
 
 has ticket_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ticket_number',
     json_ld   => 'ticketNumber',
 );
 
@@ -159,7 +159,7 @@ A ticket_token should be one of the following types:
 
 has ticket_token => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ticket_token',
     json_ld   => 'ticketToken',
 );
 
@@ -183,7 +183,7 @@ A ticketed_seat should be one of the following types:
 
 has ticketed_seat => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_ticketed_seat',
     json_ld   => 'ticketedSeat',
 );
 
@@ -220,7 +220,7 @@ A total_price should be one of the following types:
 
 has total_price => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_total_price',
     json_ld   => 'totalPrice',
 );
 
@@ -246,7 +246,7 @@ A under_name should be one of the following types:
 
 has under_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_under_name',
     json_ld   => 'underName',
 );
 

--- a/lib/SemanticWeb/Schema/TipAction.pm
+++ b/lib/SemanticWeb/Schema/TipAction.pm
@@ -56,7 +56,7 @@ A recipient should be one of the following types:
 
 has recipient => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_recipient',
     json_ld   => 'recipient',
 );
 

--- a/lib/SemanticWeb/Schema/TouristAttraction.pm
+++ b/lib/SemanticWeb/Schema/TouristAttraction.pm
@@ -73,7 +73,7 @@ A available_language should be one of the following types:
 
 has available_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_available_language',
     json_ld   => 'availableLanguage',
 );
 
@@ -100,7 +100,7 @@ A tourist_type should be one of the following types:
 
 has tourist_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_tourist_type',
     json_ld   => 'touristType',
 );
 

--- a/lib/SemanticWeb/Schema/TouristDestination.pm
+++ b/lib/SemanticWeb/Schema/TouristDestination.pm
@@ -74,7 +74,7 @@ A includes_attraction should be one of the following types:
 
 has includes_attraction => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_includes_attraction',
     json_ld   => 'includesAttraction',
 );
 
@@ -101,7 +101,7 @@ A tourist_type should be one of the following types:
 
 has tourist_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_tourist_type',
     json_ld   => 'touristType',
 );
 

--- a/lib/SemanticWeb/Schema/TouristTrip.pm
+++ b/lib/SemanticWeb/Schema/TouristTrip.pm
@@ -63,7 +63,7 @@ A tourist_type should be one of the following types:
 
 has tourist_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_tourist_type',
     json_ld   => 'touristType',
 );
 

--- a/lib/SemanticWeb/Schema/TrackAction.pm
+++ b/lib/SemanticWeb/Schema/TrackAction.pm
@@ -59,7 +59,7 @@ A delivery_method should be one of the following types:
 
 has delivery_method => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_delivery_method',
     json_ld   => 'deliveryMethod',
 );
 

--- a/lib/SemanticWeb/Schema/TradeAction.pm
+++ b/lib/SemanticWeb/Schema/TradeAction.pm
@@ -77,7 +77,7 @@ A price should be one of the following types:
 
 has price => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price',
     json_ld   => 'price',
 );
 
@@ -115,7 +115,7 @@ A price_currency should be one of the following types:
 
 has price_currency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price_currency',
     json_ld   => 'priceCurrency',
 );
 
@@ -140,7 +140,7 @@ A price_specification should be one of the following types:
 
 has price_specification => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price_specification',
     json_ld   => 'priceSpecification',
 );
 

--- a/lib/SemanticWeb/Schema/TrainTrip.pm
+++ b/lib/SemanticWeb/Schema/TrainTrip.pm
@@ -48,7 +48,7 @@ A arrival_platform should be one of the following types:
 
 has arrival_platform => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_arrival_platform',
     json_ld   => 'arrivalPlatform',
 );
 
@@ -72,7 +72,7 @@ A arrival_station should be one of the following types:
 
 has arrival_station => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_arrival_station',
     json_ld   => 'arrivalStation',
 );
 
@@ -96,7 +96,7 @@ A departure_platform should be one of the following types:
 
 has departure_platform => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_departure_platform',
     json_ld   => 'departurePlatform',
 );
 
@@ -120,7 +120,7 @@ A departure_station should be one of the following types:
 
 has departure_station => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_departure_station',
     json_ld   => 'departureStation',
 );
 
@@ -144,7 +144,7 @@ A train_name should be one of the following types:
 
 has train_name => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_train_name',
     json_ld   => 'trainName',
 );
 
@@ -168,7 +168,7 @@ A train_number should be one of the following types:
 
 has train_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_train_number',
     json_ld   => 'trainNumber',
 );
 

--- a/lib/SemanticWeb/Schema/TransferAction.pm
+++ b/lib/SemanticWeb/Schema/TransferAction.pm
@@ -50,7 +50,7 @@ A from_location should be one of the following types:
 
 has from_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_from_location',
     json_ld   => 'fromLocation',
 );
 
@@ -75,7 +75,7 @@ A to_location should be one of the following types:
 
 has to_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_to_location',
     json_ld   => 'toLocation',
 );
 

--- a/lib/SemanticWeb/Schema/TravelAction.pm
+++ b/lib/SemanticWeb/Schema/TravelAction.pm
@@ -49,7 +49,7 @@ A distance should be one of the following types:
 
 has distance => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_distance',
     json_ld   => 'distance',
 );
 

--- a/lib/SemanticWeb/Schema/Trip.pm
+++ b/lib/SemanticWeb/Schema/Trip.pm
@@ -48,7 +48,7 @@ A arrival_time should be one of the following types:
 
 has arrival_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_arrival_time',
     json_ld   => 'arrivalTime',
 );
 
@@ -72,7 +72,7 @@ A departure_time should be one of the following types:
 
 has departure_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_departure_time',
     json_ld   => 'departureTime',
 );
 
@@ -106,7 +106,7 @@ A itinerary should be one of the following types:
 
 has itinerary => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_itinerary',
     json_ld   => 'itinerary',
 );
 
@@ -132,7 +132,7 @@ A offers should be one of the following types:
 
 has offers => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_offers',
     json_ld   => 'offers',
 );
 
@@ -162,7 +162,7 @@ A part_of_trip should be one of the following types:
 
 has part_of_trip => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_part_of_trip',
     json_ld   => 'partOfTrip',
 );
 
@@ -190,7 +190,7 @@ A provider should be one of the following types:
 
 has provider => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_provider',
     json_ld   => 'provider',
 );
 
@@ -220,7 +220,7 @@ A sub_trip should be one of the following types:
 
 has sub_trip => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_sub_trip',
     json_ld   => 'subTrip',
 );
 

--- a/lib/SemanticWeb/Schema/TypeAndQuantityNode.pm
+++ b/lib/SemanticWeb/Schema/TypeAndQuantityNode.pm
@@ -49,7 +49,7 @@ A amount_of_this_good should be one of the following types:
 
 has amount_of_this_good => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_amount_of_this_good',
     json_ld   => 'amountOfThisGood',
 );
 
@@ -75,7 +75,7 @@ A business_function should be one of the following types:
 
 has business_function => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_business_function',
     json_ld   => 'businessFunction',
 );
 
@@ -101,7 +101,7 @@ A type_of_good should be one of the following types:
 
 has type_of_good => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_type_of_good',
     json_ld   => 'typeOfGood',
 );
 
@@ -127,7 +127,7 @@ A unit_code should be one of the following types:
 
 has unit_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_unit_code',
     json_ld   => 'unitCode',
 );
 
@@ -156,7 +156,7 @@ A unit_text should be one of the following types:
 
 has unit_text => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_unit_text',
     json_ld   => 'unitText',
 );
 

--- a/lib/SemanticWeb/Schema/UnitPriceSpecification.pm
+++ b/lib/SemanticWeb/Schema/UnitPriceSpecification.pm
@@ -50,7 +50,7 @@ A billing_increment should be one of the following types:
 
 has billing_increment => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_billing_increment',
     json_ld   => 'billingIncrement',
 );
 
@@ -76,7 +76,7 @@ A price_type should be one of the following types:
 
 has price_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_price_type',
     json_ld   => 'priceType',
 );
 
@@ -102,7 +102,7 @@ A reference_quantity should be one of the following types:
 
 has reference_quantity => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_reference_quantity',
     json_ld   => 'referenceQuantity',
 );
 
@@ -128,7 +128,7 @@ A unit_code should be one of the following types:
 
 has unit_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_unit_code',
     json_ld   => 'unitCode',
 );
 
@@ -157,7 +157,7 @@ A unit_text should be one of the following types:
 
 has unit_text => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_unit_text',
     json_ld   => 'unitText',
 );
 

--- a/lib/SemanticWeb/Schema/UpdateAction.pm
+++ b/lib/SemanticWeb/Schema/UpdateAction.pm
@@ -48,7 +48,7 @@ A collection should be one of the following types:
 
 has collection => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_collection',
     json_ld   => 'collection',
 );
 
@@ -72,7 +72,7 @@ A target_collection should be one of the following types:
 
 has target_collection => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_target_collection',
     json_ld   => 'targetCollection',
 );
 

--- a/lib/SemanticWeb/Schema/UserComments.pm
+++ b/lib/SemanticWeb/Schema/UserComments.pm
@@ -56,7 +56,7 @@ A comment_text should be one of the following types:
 
 has comment_text => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_comment_text',
     json_ld   => 'commentText',
 );
 
@@ -80,7 +80,7 @@ A comment_time should be one of the following types:
 
 has comment_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_comment_time',
     json_ld   => 'commentTime',
 );
 
@@ -107,7 +107,7 @@ A creator should be one of the following types:
 
 has creator => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_creator',
     json_ld   => 'creator',
 );
 
@@ -131,7 +131,7 @@ A discusses should be one of the following types:
 
 has discusses => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_discusses',
     json_ld   => 'discusses',
 );
 
@@ -155,7 +155,7 @@ A reply_to_url should be one of the following types:
 
 has reply_to_url => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_reply_to_url',
     json_ld   => 'replyToUrl',
 );
 

--- a/lib/SemanticWeb/Schema/Vehicle.pm
+++ b/lib/SemanticWeb/Schema/Vehicle.pm
@@ -64,7 +64,7 @@ A acceleration_time should be one of the following types:
 
 has acceleration_time => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_acceleration_time',
     json_ld   => 'accelerationTime',
 );
 
@@ -91,7 +91,7 @@ A body_type should be one of the following types:
 
 has body_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_body_type',
     json_ld   => 'bodyType',
 );
 
@@ -121,7 +121,7 @@ A call_sign should be one of the following types:
 
 has call_sign => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_call_sign',
     json_ld   => 'callSign',
 );
 
@@ -153,7 +153,7 @@ A cargo_volume should be one of the following types:
 
 has cargo_volume => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cargo_volume',
     json_ld   => 'cargoVolume',
 );
 
@@ -178,7 +178,7 @@ A date_vehicle_first_registered should be one of the following types:
 
 has date_vehicle_first_registered => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_date_vehicle_first_registered',
     json_ld   => 'dateVehicleFirstRegistered',
 );
 
@@ -205,7 +205,7 @@ A drive_wheel_configuration should be one of the following types:
 
 has drive_wheel_configuration => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_drive_wheel_configuration',
     json_ld   => 'driveWheelConfiguration',
 );
 
@@ -231,7 +231,7 @@ A emissions_co2 should be one of the following types:
 
 has emissions_co2 => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_emissions_co2',
     json_ld   => 'emissionsCO2',
 );
 
@@ -263,7 +263,7 @@ A fuel_capacity should be one of the following types:
 
 has fuel_capacity => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_fuel_capacity',
     json_ld   => 'fuelCapacity',
 );
 
@@ -305,7 +305,7 @@ A fuel_consumption should be one of the following types:
 
 has fuel_consumption => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_fuel_consumption',
     json_ld   => 'fuelConsumption',
 );
 
@@ -347,7 +347,7 @@ A fuel_efficiency should be one of the following types:
 
 has fuel_efficiency => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_fuel_efficiency',
     json_ld   => 'fuelEfficiency',
 );
 
@@ -375,7 +375,7 @@ A fuel_type should be one of the following types:
 
 has fuel_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_fuel_type',
     json_ld   => 'fuelType',
 );
 
@@ -399,7 +399,7 @@ A known_vehicle_damages should be one of the following types:
 
 has known_vehicle_damages => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_known_vehicle_damages',
     json_ld   => 'knownVehicleDamages',
 );
 
@@ -425,7 +425,7 @@ A meets_emission_standard should be one of the following types:
 
 has meets_emission_standard => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_meets_emission_standard',
     json_ld   => 'meetsEmissionStandard',
 );
 
@@ -455,7 +455,7 @@ A mileage_from_odometer should be one of the following types:
 
 has mileage_from_odometer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_mileage_from_odometer',
     json_ld   => 'mileageFromOdometer',
 );
 
@@ -480,7 +480,7 @@ A model_date should be one of the following types:
 
 has model_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_model_date',
     json_ld   => 'modelDate',
 );
 
@@ -506,7 +506,7 @@ A number_of_airbags should be one of the following types:
 
 has number_of_airbags => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_airbags',
     json_ld   => 'numberOfAirbags',
 );
 
@@ -536,7 +536,7 @@ A number_of_axles should be one of the following types:
 
 has number_of_axles => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_axles',
     json_ld   => 'numberOfAxles',
 );
 
@@ -566,7 +566,7 @@ A number_of_doors should be one of the following types:
 
 has number_of_doors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_doors',
     json_ld   => 'numberOfDoors',
 );
 
@@ -597,7 +597,7 @@ A number_of_forward_gears should be one of the following types:
 
 has number_of_forward_gears => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_forward_gears',
     json_ld   => 'numberOfForwardGears',
 );
 
@@ -628,7 +628,7 @@ A number_of_previous_owners should be one of the following types:
 
 has number_of_previous_owners => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_previous_owners',
     json_ld   => 'numberOfPreviousOwners',
 );
 
@@ -672,7 +672,7 @@ A payload should be one of the following types:
 
 has payload => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_payload',
     json_ld   => 'payload',
 );
 
@@ -696,7 +696,7 @@ A production_date should be one of the following types:
 
 has production_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_production_date',
     json_ld   => 'productionDate',
 );
 
@@ -720,7 +720,7 @@ A purchase_date should be one of the following types:
 
 has purchase_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_purchase_date',
     json_ld   => 'purchaseDate',
 );
 
@@ -752,7 +752,7 @@ A seating_capacity should be one of the following types:
 
 has seating_capacity => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seating_capacity',
     json_ld   => 'seatingCapacity',
 );
 
@@ -791,7 +791,7 @@ A speed should be one of the following types:
 
 has speed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_speed',
     json_ld   => 'speed',
 );
 
@@ -815,7 +815,7 @@ A steering_position should be one of the following types:
 
 has steering_position => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_steering_position',
     json_ld   => 'steeringPosition',
 );
 
@@ -857,7 +857,7 @@ A tongue_weight should be one of the following types:
 
 has tongue_weight => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_tongue_weight',
     json_ld   => 'tongueWeight',
 );
 
@@ -896,7 +896,7 @@ A trailer_weight should be one of the following types:
 
 has trailer_weight => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_trailer_weight',
     json_ld   => 'trailerWeight',
 );
 
@@ -921,7 +921,7 @@ A vehicle_configuration should be one of the following types:
 
 has vehicle_configuration => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_vehicle_configuration',
     json_ld   => 'vehicleConfiguration',
 );
 
@@ -945,7 +945,7 @@ A vehicle_engine should be one of the following types:
 
 has vehicle_engine => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_vehicle_engine',
     json_ld   => 'vehicleEngine',
 );
 
@@ -970,7 +970,7 @@ A vehicle_identification_number should be one of the following types:
 
 has vehicle_identification_number => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_vehicle_identification_number',
     json_ld   => 'vehicleIdentificationNumber',
 );
 
@@ -994,7 +994,7 @@ A vehicle_interior_color should be one of the following types:
 
 has vehicle_interior_color => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_vehicle_interior_color',
     json_ld   => 'vehicleInteriorColor',
 );
 
@@ -1021,7 +1021,7 @@ A vehicle_interior_type should be one of the following types:
 
 has vehicle_interior_type => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_vehicle_interior_type',
     json_ld   => 'vehicleInteriorType',
 );
 
@@ -1046,7 +1046,7 @@ A vehicle_model_date should be one of the following types:
 
 has vehicle_model_date => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_vehicle_model_date',
     json_ld   => 'vehicleModelDate',
 );
 
@@ -1078,7 +1078,7 @@ A vehicle_seating_capacity should be one of the following types:
 
 has vehicle_seating_capacity => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_vehicle_seating_capacity',
     json_ld   => 'vehicleSeatingCapacity',
 );
 
@@ -1107,7 +1107,7 @@ A vehicle_special_usage should be one of the following types:
 
 has vehicle_special_usage => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_vehicle_special_usage',
     json_ld   => 'vehicleSpecialUsage',
 );
 
@@ -1134,7 +1134,7 @@ A vehicle_transmission should be one of the following types:
 
 has vehicle_transmission => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_vehicle_transmission',
     json_ld   => 'vehicleTransmission',
 );
 
@@ -1175,7 +1175,7 @@ A weight_total should be one of the following types:
 
 has weight_total => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_weight_total',
     json_ld   => 'weightTotal',
 );
 
@@ -1205,7 +1205,7 @@ A wheelbase should be one of the following types:
 
 has wheelbase => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_wheelbase',
     json_ld   => 'wheelbase',
 );
 

--- a/lib/SemanticWeb/Schema/Vein.pm
+++ b/lib/SemanticWeb/Schema/Vein.pm
@@ -48,7 +48,7 @@ A drains_to should be one of the following types:
 
 has drains_to => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_drains_to',
     json_ld   => 'drainsTo',
 );
 
@@ -75,7 +75,7 @@ A region_drained should be one of the following types:
 
 has region_drained => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_region_drained',
     json_ld   => 'regionDrained',
 );
 
@@ -100,7 +100,7 @@ A tributary should be one of the following types:
 
 has tributary => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_tributary',
     json_ld   => 'tributary',
 );
 

--- a/lib/SemanticWeb/Schema/VideoGame.pm
+++ b/lib/SemanticWeb/Schema/VideoGame.pm
@@ -51,7 +51,7 @@ A actor should be one of the following types:
 
 has actor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actor',
     json_ld   => 'actor',
 );
 
@@ -76,7 +76,7 @@ A actors should be one of the following types:
 
 has actors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actors',
     json_ld   => 'actors',
 );
 
@@ -100,7 +100,7 @@ A cheat_code should be one of the following types:
 
 has cheat_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cheat_code',
     json_ld   => 'cheatCode',
 );
 
@@ -126,7 +126,7 @@ A director should be one of the following types:
 
 has director => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_director',
     json_ld   => 'director',
 );
 
@@ -151,7 +151,7 @@ A directors should be one of the following types:
 
 has directors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_directors',
     json_ld   => 'directors',
 );
 
@@ -183,7 +183,7 @@ A game_platform should be one of the following types:
 
 has game_platform => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_game_platform',
     json_ld   => 'gamePlatform',
 );
 
@@ -207,7 +207,7 @@ A game_server should be one of the following types:
 
 has game_server => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_game_server',
     json_ld   => 'gameServer',
 );
 
@@ -231,7 +231,7 @@ A game_tip should be one of the following types:
 
 has game_tip => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_game_tip',
     json_ld   => 'gameTip',
 );
 
@@ -257,7 +257,7 @@ A music_by should be one of the following types:
 
 has music_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_music_by',
     json_ld   => 'musicBy',
 );
 
@@ -283,7 +283,7 @@ A play_mode should be one of the following types:
 
 has play_mode => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_play_mode',
     json_ld   => 'playMode',
 );
 
@@ -307,7 +307,7 @@ A trailer should be one of the following types:
 
 has trailer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_trailer',
     json_ld   => 'trailer',
 );
 

--- a/lib/SemanticWeb/Schema/VideoGameSeries.pm
+++ b/lib/SemanticWeb/Schema/VideoGameSeries.pm
@@ -50,7 +50,7 @@ A actor should be one of the following types:
 
 has actor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actor',
     json_ld   => 'actor',
 );
 
@@ -75,7 +75,7 @@ A actors should be one of the following types:
 
 has actors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actors',
     json_ld   => 'actors',
 );
 
@@ -100,7 +100,7 @@ A character_attribute should be one of the following types:
 
 has character_attribute => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_character_attribute',
     json_ld   => 'characterAttribute',
 );
 
@@ -124,7 +124,7 @@ A cheat_code should be one of the following types:
 
 has cheat_code => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_cheat_code',
     json_ld   => 'cheatCode',
 );
 
@@ -148,7 +148,7 @@ A contains_season should be one of the following types:
 
 has contains_season => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_contains_season',
     json_ld   => 'containsSeason',
 );
 
@@ -174,7 +174,7 @@ A director should be one of the following types:
 
 has director => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_director',
     json_ld   => 'director',
 );
 
@@ -199,7 +199,7 @@ A directors should be one of the following types:
 
 has directors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_directors',
     json_ld   => 'directors',
 );
 
@@ -223,7 +223,7 @@ A episode should be one of the following types:
 
 has episode => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_episode',
     json_ld   => 'episode',
 );
 
@@ -247,7 +247,7 @@ A episodes should be one of the following types:
 
 has episodes => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_episodes',
     json_ld   => 'episodes',
 );
 
@@ -272,7 +272,7 @@ A game_item should be one of the following types:
 
 has game_item => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_game_item',
     json_ld   => 'gameItem',
 );
 
@@ -300,7 +300,7 @@ A game_location should be one of the following types:
 
 has game_location => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_game_location',
     json_ld   => 'gameLocation',
 );
 
@@ -332,7 +332,7 @@ A game_platform should be one of the following types:
 
 has game_platform => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_game_platform',
     json_ld   => 'gamePlatform',
 );
 
@@ -358,7 +358,7 @@ A music_by should be one of the following types:
 
 has music_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_music_by',
     json_ld   => 'musicBy',
 );
 
@@ -382,7 +382,7 @@ A number_of_episodes should be one of the following types:
 
 has number_of_episodes => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_episodes',
     json_ld   => 'numberOfEpisodes',
 );
 
@@ -406,7 +406,7 @@ A number_of_players should be one of the following types:
 
 has number_of_players => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_players',
     json_ld   => 'numberOfPlayers',
 );
 
@@ -430,7 +430,7 @@ A number_of_seasons should be one of the following types:
 
 has number_of_seasons => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_number_of_seasons',
     json_ld   => 'numberOfSeasons',
 );
 
@@ -456,7 +456,7 @@ A play_mode should be one of the following types:
 
 has play_mode => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_play_mode',
     json_ld   => 'playMode',
 );
 
@@ -481,7 +481,7 @@ A production_company should be one of the following types:
 
 has production_company => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_production_company',
     json_ld   => 'productionCompany',
 );
 
@@ -506,7 +506,7 @@ A quest should be one of the following types:
 
 has quest => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_quest',
     json_ld   => 'quest',
 );
 
@@ -530,7 +530,7 @@ A season should be one of the following types:
 
 has season => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_season',
     json_ld   => 'season',
 );
 
@@ -554,7 +554,7 @@ A seasons should be one of the following types:
 
 has seasons => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_seasons',
     json_ld   => 'seasons',
 );
 
@@ -578,7 +578,7 @@ A trailer should be one of the following types:
 
 has trailer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_trailer',
     json_ld   => 'trailer',
 );
 

--- a/lib/SemanticWeb/Schema/VideoObject.pm
+++ b/lib/SemanticWeb/Schema/VideoObject.pm
@@ -50,7 +50,7 @@ A actor should be one of the following types:
 
 has actor => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actor',
     json_ld   => 'actor',
 );
 
@@ -75,7 +75,7 @@ A actors should be one of the following types:
 
 has actors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_actors',
     json_ld   => 'actors',
 );
 
@@ -108,7 +108,7 @@ A caption should be one of the following types:
 
 has caption => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_caption',
     json_ld   => 'caption',
 );
 
@@ -134,7 +134,7 @@ A director should be one of the following types:
 
 has director => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_director',
     json_ld   => 'director',
 );
 
@@ -159,7 +159,7 @@ A directors should be one of the following types:
 
 has directors => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_directors',
     json_ld   => 'directors',
 );
 
@@ -185,7 +185,7 @@ A music_by should be one of the following types:
 
 has music_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_music_by',
     json_ld   => 'musicBy',
 );
 
@@ -209,7 +209,7 @@ A thumbnail should be one of the following types:
 
 has thumbnail => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_thumbnail',
     json_ld   => 'thumbnail',
 );
 
@@ -234,7 +234,7 @@ A transcript should be one of the following types:
 
 has transcript => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_transcript',
     json_ld   => 'transcript',
 );
 
@@ -258,7 +258,7 @@ A video_frame_size should be one of the following types:
 
 has video_frame_size => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_video_frame_size',
     json_ld   => 'videoFrameSize',
 );
 
@@ -282,7 +282,7 @@ A video_quality should be one of the following types:
 
 has video_quality => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_video_quality',
     json_ld   => 'videoQuality',
 );
 

--- a/lib/SemanticWeb/Schema/VisualArtwork.pm
+++ b/lib/SemanticWeb/Schema/VisualArtwork.pm
@@ -52,7 +52,7 @@ A art_edition should be one of the following types:
 
 has art_edition => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_art_edition',
     json_ld   => 'artEdition',
 );
 
@@ -78,7 +78,7 @@ A art_medium should be one of the following types:
 
 has art_medium => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_art_medium',
     json_ld   => 'artMedium',
 );
 
@@ -103,7 +103,7 @@ A artform should be one of the following types:
 
 has artform => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_artform',
     json_ld   => 'artform',
 );
 
@@ -129,7 +129,7 @@ A artist should be one of the following types:
 
 has artist => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_artist',
     json_ld   => 'artist',
 );
 
@@ -154,7 +154,7 @@ A artwork_surface should be one of the following types:
 
 has artwork_surface => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_artwork_surface',
     json_ld   => 'artworkSurface',
 );
 
@@ -178,7 +178,7 @@ A colorist should be one of the following types:
 
 has colorist => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_colorist',
     json_ld   => 'colorist',
 );
 
@@ -204,7 +204,7 @@ A depth should be one of the following types:
 
 has depth => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_depth',
     json_ld   => 'depth',
 );
 
@@ -230,7 +230,7 @@ A height should be one of the following types:
 
 has height => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_height',
     json_ld   => 'height',
 );
 
@@ -255,7 +255,7 @@ A inker should be one of the following types:
 
 has inker => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_inker',
     json_ld   => 'inker',
 );
 
@@ -280,7 +280,7 @@ A letterer should be one of the following types:
 
 has letterer => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_letterer',
     json_ld   => 'letterer',
 );
 
@@ -304,7 +304,7 @@ A penciler should be one of the following types:
 
 has penciler => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_penciler',
     json_ld   => 'penciler',
 );
 
@@ -329,7 +329,7 @@ A surface should be one of the following types:
 
 has surface => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_surface',
     json_ld   => 'surface',
 );
 
@@ -355,7 +355,7 @@ A width should be one of the following types:
 
 has width => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_width',
     json_ld   => 'width',
 );
 

--- a/lib/SemanticWeb/Schema/VoteAction.pm
+++ b/lib/SemanticWeb/Schema/VoteAction.pm
@@ -49,7 +49,7 @@ A candidate should be one of the following types:
 
 has candidate => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_candidate',
     json_ld   => 'candidate',
 );
 

--- a/lib/SemanticWeb/Schema/WarrantyPromise.pm
+++ b/lib/SemanticWeb/Schema/WarrantyPromise.pm
@@ -51,7 +51,7 @@ A duration_of_warranty should be one of the following types:
 
 has duration_of_warranty => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_duration_of_warranty',
     json_ld   => 'durationOfWarranty',
 );
 
@@ -75,7 +75,7 @@ A warranty_scope should be one of the following types:
 
 has warranty_scope => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_warranty_scope',
     json_ld   => 'warrantyScope',
 );
 

--- a/lib/SemanticWeb/Schema/WebAPI.pm
+++ b/lib/SemanticWeb/Schema/WebAPI.pm
@@ -51,7 +51,7 @@ A documentation should be one of the following types:
 
 has documentation => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_documentation',
     json_ld   => 'documentation',
 );
 

--- a/lib/SemanticWeb/Schema/WebApplication.pm
+++ b/lib/SemanticWeb/Schema/WebApplication.pm
@@ -49,7 +49,7 @@ A browser_requirements should be one of the following types:
 
 has browser_requirements => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_browser_requirements',
     json_ld   => 'browserRequirements',
 );
 

--- a/lib/SemanticWeb/Schema/WebPage.pm
+++ b/lib/SemanticWeb/Schema/WebPage.pm
@@ -59,7 +59,7 @@ A breadcrumb should be one of the following types:
 
 has breadcrumb => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_breadcrumb',
     json_ld   => 'breadcrumb',
 );
 
@@ -84,7 +84,7 @@ A last_reviewed should be one of the following types:
 
 has last_reviewed => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_last_reviewed',
     json_ld   => 'lastReviewed',
 );
 
@@ -108,7 +108,7 @@ A main_content_of_page should be one of the following types:
 
 has main_content_of_page => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_main_content_of_page',
     json_ld   => 'mainContentOfPage',
 );
 
@@ -132,7 +132,7 @@ A primary_image_of_page should be one of the following types:
 
 has primary_image_of_page => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_primary_image_of_page',
     json_ld   => 'primaryImageOfPage',
 );
 
@@ -156,7 +156,7 @@ A related_link should be one of the following types:
 
 has related_link => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_related_link',
     json_ld   => 'relatedLink',
 );
 
@@ -183,7 +183,7 @@ A reviewed_by should be one of the following types:
 
 has reviewed_by => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_reviewed_by',
     json_ld   => 'reviewedBy',
 );
 
@@ -208,7 +208,7 @@ A significant_link should be one of the following types:
 
 has significant_link => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_significant_link',
     json_ld   => 'significantLink',
 );
 
@@ -233,7 +233,7 @@ A significant_links should be one of the following types:
 
 has significant_links => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_significant_links',
     json_ld   => 'significantLinks',
 );
 
@@ -284,7 +284,7 @@ A speakable should be one of the following types:
 
 has speakable => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_speakable',
     json_ld   => 'speakable',
 );
 
@@ -308,7 +308,7 @@ A specialty should be one of the following types:
 
 has specialty => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_specialty',
     json_ld   => 'specialty',
 );
 

--- a/lib/SemanticWeb/Schema/WebPageElement.pm
+++ b/lib/SemanticWeb/Schema/WebPageElement.pm
@@ -57,7 +57,7 @@ A css_selector should be one of the following types:
 
 has css_selector => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_css_selector',
     json_ld   => 'cssSelector',
 );
 
@@ -90,7 +90,7 @@ A xpath should be one of the following types:
 
 has xpath => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_xpath',
     json_ld   => 'xpath',
 );
 

--- a/lib/SemanticWeb/Schema/WebSite.pm
+++ b/lib/SemanticWeb/Schema/WebSite.pm
@@ -51,7 +51,7 @@ A issn should be one of the following types:
 
 has issn => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_issn',
     json_ld   => 'issn',
 );
 

--- a/lib/SemanticWeb/Schema/WinAction.pm
+++ b/lib/SemanticWeb/Schema/WinAction.pm
@@ -48,7 +48,7 @@ A loser should be one of the following types:
 
 has loser => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_loser',
     json_ld   => 'loser',
 );
 

--- a/lib/SemanticWeb/Schema/WorkBasedProgram.pm
+++ b/lib/SemanticWeb/Schema/WorkBasedProgram.pm
@@ -66,7 +66,7 @@ A occupational_category should be one of the following types:
 
 has occupational_category => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_occupational_category',
     json_ld   => 'occupationalCategory',
 );
 
@@ -90,7 +90,7 @@ A training_salary should be one of the following types:
 
 has training_salary => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_training_salary',
     json_ld   => 'trainingSalary',
 );
 

--- a/lib/SemanticWeb/Schema/WriteAction.pm
+++ b/lib/SemanticWeb/Schema/WriteAction.pm
@@ -58,7 +58,7 @@ A in_language should be one of the following types:
 
 has in_language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_in_language',
     json_ld   => 'inLanguage',
 );
 
@@ -82,7 +82,7 @@ A language should be one of the following types:
 
 has language => (
     is        => 'rw',
-    predicate => 1,
+    predicate => '_has_language',
     json_ld   => 'language',
 );
 

--- a/t/01-simple.t
+++ b/t/01-simple.t
@@ -32,4 +32,7 @@ cmp_json(
 
 note $json;
 
+eval { require SemanticWeb::Schema::Place; };
+ok(!$@, 'load SemanticWeb::Schema::Place') || diag $@;
+
 done_testing;


### PR DESCRIPTION
Hi @robrwo

Please review the PR.

## Problem

When `SemanticWeb::Schema::Place` was used, an error occurred and use failed

```
You cannot overwrite a locally defined method (has_map) with a predicate at /Users/xxxxxxx/develop/SemanticWeb-Schema/local/lib/perl5/MooX/JSON_LD.pm line 133.
```

## Reason

`predicate` option of `Moo` set this to just `1`, the predicate is automatically named `has_${attr_name}`.
cf. https://metacpan.org/pod/Moo#predicate

[Place - Schema.org](http://schema.org/Place) ( [lib/SemanticWeb/Schema/Place.pm](https://github.com/robrwo/SemanticWeb-Schema/blob/e7d00a3c8d1c3df0ca08e1104674bea6d67056ce/lib/SemanticWeb/Schema/Place.pm) ) has `has_map` & `map` properties.

https://github.com/robrwo/SemanticWeb-Schema/blob/e7d00a3c8d1c3df0ca08e1104674bea6d67056ce/lib/SemanticWeb/Schema/Place.pm#L711-L734
https://github.com/robrwo/SemanticWeb-Schema/blob/e7d00a3c8d1c3df0ca08e1104674bea6d67056ce/lib/SemanticWeb/Schema/Place.pm#L875-L896

The `has_map` property of schema.org and the `has_map` property that is automatically generated with the predicate option for `map` propery is conflict.